### PR TITLE
Allow overrride of build date

### DIFF
--- a/lib/Creator/RSSCreator091.php
+++ b/lib/Creator/RSSCreator091.php
@@ -63,7 +63,7 @@ class RSSCreator091 extends FeedCreator {
         $feed.= "        <description>".$this->getDescription()."</description>\n";
         $feed.= "        <link>".$this->link."</link>\n";
         $now = new FeedDate();
-        $feed.= "        <lastBuildDate>".htmlspecialchars($now->rfc822())."</lastBuildDate>\n";
+        $feed.= "        <lastBuildDate>".htmlspecialchars($this->lastBuildDate ?: $now->rfc822())."</lastBuildDate>\n";
         $feed.= "        <generator>".FEEDCREATOR_VERSION."</generator>\n";
 
         if ($this->image!=null) {


### PR DESCRIPTION
Don't use current date, when you manually set the build date.
