### PR TITLE
PSR1/2 reformatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# This file is for unifying the coding style for different editors and IDEs
+# editorconfig.org
+
+# PHP PSR-2 Coding Standards
+# http://www.php-fig.org/psr/psr-2/
+
+root = true
+
+[*.php]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+

--- a/lib/Creator/AtomCreator03.php
+++ b/lib/Creator/AtomCreator03.php
@@ -1,89 +1,95 @@
 <?php
+
 /**
  * AtomCreator03 is a FeedCreator that implements the atom specification,
  * as in http://www.intertwingly.net/wiki/pie/FrontPage.
  * Please note that just by using AtomCreator03 you won't automatically
  * produce valid atom files. For example, you have to specify either an editor
  * for the feed or an author for every single feed item.
- *
  * Some elements have not been implemented yet. These are (incomplete list):
  * author URL, item author's email and URL, item contents, alternate links,
  * other link content types than text/html. Some of them may be created with
  * AtomCreator03::additionalElements.
  *
- * @see FeedCreator#additionalElements
- * @since 1.6
- * @author Kai Blankenhorn <kaib@bitfolge.de>, Scott Reynen <scott@randomchaos.com>
+ * @see     FeedCreator#additionalElements
+ * @since   1.6
+ * @author  Kai Blankenhorn <kaib@bitfolge.de>, Scott Reynen <scott@randomchaos.com>
  * @package de.bitfolge.feedcreator
  */
-class AtomCreator03 extends FeedCreator {
+class AtomCreator03 extends FeedCreator
+{
 
     /**
      * AtomCreator03 constructor.
      */
-    public function __construct() {
+    public function __construct()
+    {
         $this->contentType = "application/atom+xml";
         $this->encoding = "utf-8";
     }
 
     /** @inheritdoc */
-    public function createFeed() {
+    public function createFeed()
+    {
         $feed = "<?xml version=\"1.0\" encoding=\"".$this->encoding."\"?>\n";
-        $feed.= $this->_createGeneratorComment();
-        $feed.= $this->_createStylesheetReferences();
-        $feed.= "<feed version=\"0.3\" xmlns=\"http://purl.org/atom/ns#\"";
-        if ($this->format=='TOOLBAR') {
-            $feed.= " xmlns:gtb=\"http://toolbar.google.com/custombuttons/\"";
+        $feed .= $this->_createGeneratorComment();
+        $feed .= $this->_createStylesheetReferences();
+        $feed .= "<feed version=\"0.3\" xmlns=\"http://purl.org/atom/ns#\"";
+        if ($this->format == 'TOOLBAR') {
+            $feed .= " xmlns:gtb=\"http://toolbar.google.com/custombuttons/\"";
         }
-        if ($this->language!="") {
-            $feed.= " xml:lang=\"".$this->language."\"";
+        if ($this->language != "") {
+            $feed .= " xml:lang=\"".$this->language."\"";
         }
-        $feed.= ">\n";
-        $feed.= "    <title>".htmlspecialchars($this->title)."</title>\n";
-        $feed.= "    <tagline>".htmlspecialchars($this->description)."</tagline>\n";
-        $feed.= "    <link rel=\"alternate\" type=\"text/html\" href=\"".htmlspecialchars($this->link)."\"/>\n";
-        $feed.= "    <id>".htmlspecialchars($this->link)."</id>\n";
+        $feed .= ">\n";
+        $feed .= "    <title>".htmlspecialchars($this->title)."</title>\n";
+        $feed .= "    <tagline>".htmlspecialchars($this->description)."</tagline>\n";
+        $feed .= "    <link rel=\"alternate\" type=\"text/html\" href=\"".htmlspecialchars($this->link)."\"/>\n";
+        $feed .= "    <id>".htmlspecialchars($this->link)."</id>\n";
         $now = new FeedDate();
-        $feed.= "    <modified>".htmlspecialchars($now->iso8601())."</modified>\n";
-        if ($this->editor!="") {
-            $feed.= "    <author>\n";
-            $feed.= "        <name>".$this->editor."</name>\n";
-            if ($this->editorEmail!="") {
-                $feed.= "        <email>".$this->editorEmail."</email>\n";
+        $feed .= "    <modified>".htmlspecialchars($now->iso8601())."</modified>\n";
+        if ($this->editor != "") {
+            $feed .= "    <author>\n";
+            $feed .= "        <name>".$this->editor."</name>\n";
+            if ($this->editorEmail != "") {
+                $feed .= "        <email>".$this->editorEmail."</email>\n";
             }
-            $feed.= "    </author>\n";
+            $feed .= "    </author>\n";
         }
-        $feed.= "    <generator>".FEEDCREATOR_VERSION."</generator>\n";
-        $feed.= $this->_createAdditionalElements($this->additionalElements, "    ");
-        for ($i=0;$i<count($this->items);$i++) {
-            $feed.= "    <entry>\n";
-            $feed.= "        <title>".htmlspecialchars(strip_tags($this->items[$i]->title))."</title>\n";
-            $feed.= "        <link rel=\"alternate\" type=\"text/html\" href=\"".htmlspecialchars($this->items[$i]->link)."\"/>\n";
-            if ($this->items[$i]->date=="") {
+        $feed .= "    <generator>".FEEDCREATOR_VERSION."</generator>\n";
+        $feed .= $this->_createAdditionalElements($this->additionalElements, "    ");
+        for ($i = 0; $i < count($this->items); $i++) {
+            $feed .= "    <entry>\n";
+            $feed .= "        <title>".htmlspecialchars(strip_tags($this->items[$i]->title))."</title>\n";
+            $feed .= "        <link rel=\"alternate\" type=\"text/html\" href=\"".htmlspecialchars(
+                    $this->items[$i]->link
+                )."\"/>\n";
+            if ($this->items[$i]->date == "") {
                 $this->items[$i]->date = time();
             }
             $itemDate = new FeedDate($this->items[$i]->date);
-            $feed.= "        <created>".htmlspecialchars($itemDate->iso8601())."</created>\n";
-            $feed.= "        <issued>".htmlspecialchars($itemDate->iso8601())."</issued>\n";
-            $feed.= "        <modified>".htmlspecialchars($itemDate->iso8601())."</modified>\n";
-            $feed.= "        <id>".htmlspecialchars($this->items[$i]->link)."</id>\n";
-            $feed.= $this->_createAdditionalElements($this->items[$i]->additionalElements, "        ");
-            if ($this->items[$i]->author!="") {
-                $feed.= "        <author>\n";
-                $feed.= "            <name>".htmlspecialchars($this->items[$i]->author)."</name>\n";
-                $feed.= "        </author>\n";
+            $feed .= "        <created>".htmlspecialchars($itemDate->iso8601())."</created>\n";
+            $feed .= "        <issued>".htmlspecialchars($itemDate->iso8601())."</issued>\n";
+            $feed .= "        <modified>".htmlspecialchars($itemDate->iso8601())."</modified>\n";
+            $feed .= "        <id>".htmlspecialchars($this->items[$i]->link)."</id>\n";
+            $feed .= $this->_createAdditionalElements($this->items[$i]->additionalElements, "        ");
+            if ($this->items[$i]->author != "") {
+                $feed .= "        <author>\n";
+                $feed .= "            <name>".htmlspecialchars($this->items[$i]->author)."</name>\n";
+                $feed .= "        </author>\n";
             }
-            if ($this->items[$i]->description!="") {
-                $feed.= "        <summary>".htmlspecialchars($this->items[$i]->description)."</summary>\n";
+            if ($this->items[$i]->description != "") {
+                $feed .= "        <summary>".htmlspecialchars($this->items[$i]->description)."</summary>\n";
             }
             if (isset($this->items[$i]->thumbdata)) {
-                $feed.= "        <gtb:icon mode=\"base64\" type=\"image/jpeg\">\n";
-                $feed.= chunk_split(base64_encode($this->items[$i]->thumbdata))."\n";
-                $feed.= "        </gtb:icon>\n";
+                $feed .= "        <gtb:icon mode=\"base64\" type=\"image/jpeg\">\n";
+                $feed .= chunk_split(base64_encode($this->items[$i]->thumbdata))."\n";
+                $feed .= "        </gtb:icon>\n";
             }
-            $feed.= "    </entry>\n";
+            $feed .= "    </entry>\n";
         }
-        $feed.= "</feed>\n";
+        $feed .= "</feed>\n";
+
         return $feed;
     }
 }

--- a/lib/Creator/AtomCreator10.php
+++ b/lib/Creator/AtomCreator10.php
@@ -1,156 +1,163 @@
 <?php
+
 /**
  * AtomCreator10 is a FeedCreator that implements the atom specification,
  * as in http://www.atomenabled.org/developers/syndication/atom-format-spec.php
  * Please note that just by using AtomCreator10 you won't automatically
  * produce valid atom files. For example, you have to specify either an editor
  * for the feed or an author for every single feed item.
- *
  * Some elements have not been implemented yet. These are (incomplete list):
  * author URL, item author's email and URL, item contents, alternate links,
  * other link content types than text/html. Some of them may be created with
  * AtomCreator10::additionalElements.
  *
- * @see FeedCreator#additionalElements
- * @since 1.7.2-mod (modified)
- * @author Mohammad Hafiz Ismail (mypapit@gmail.com)
+ * @see     FeedCreator#additionalElements
+ * @since   1.7.2-mod (modified)
+ * @author  Mohammad Hafiz Ismail (mypapit@gmail.com)
  * @package de.bitfolge.feedcreator
  */
-class AtomCreator10 extends FeedCreator {
+class AtomCreator10 extends FeedCreator
+{
 
     /**
      * AtomCreator10 constructor.
      */
-    public function __construct() {
+    public function __construct()
+    {
         $this->contentType = "application/atom+xml";
         $this->encoding = "utf-8";
     }
 
     /** @inheritdoc */
-    public function createFeed() {
+    public function createFeed()
+    {
         $feed = "<?xml version=\"1.0\" encoding=\"".$this->encoding."\"?>\n";
-        $feed.= $this->_createGeneratorComment();
-        $feed.= $this->_createStylesheetReferences();
-        $feed.= "<feed xmlns=\"http://www.w3.org/2005/Atom\"";
-        if (!empty($this->items[0]->lat))
-        {
-            $feed.= " xmlns:georss=\"http://www.georss.org/georss\"\n";
+        $feed .= $this->_createGeneratorComment();
+        $feed .= $this->_createStylesheetReferences();
+        $feed .= "<feed xmlns=\"http://www.w3.org/2005/Atom\"";
+        if (!empty($this->items[0]->lat)) {
+            $feed .= " xmlns:georss=\"http://www.georss.org/georss\"\n";
         }
-        if ($this->language!=""){
-            $feed.= " xml:lang=\"".$this->language."\"";
+        if ($this->language != "") {
+            $feed .= " xml:lang=\"".$this->language."\"";
         }
-        $feed.= ">\n";
-        $feed.= "    <title>".htmlspecialchars($this->title)."</title>\n";
-        $feed.= "    <subtitle>".htmlspecialchars($this->description)."</subtitle>\n";
-        $feed.= "    <link rel=\"alternate\" type=\"text/html\" href=\"".htmlspecialchars($this->link)."\"/>\n";
-        $feed.= "    <id>".htmlspecialchars($this->link)."</id>\n";
+        $feed .= ">\n";
+        $feed .= "    <title>".htmlspecialchars($this->title)."</title>\n";
+        $feed .= "    <subtitle>".htmlspecialchars($this->description)."</subtitle>\n";
+        $feed .= "    <link rel=\"alternate\" type=\"text/html\" href=\"".htmlspecialchars($this->link)."\"/>\n";
+        $feed .= "    <id>".htmlspecialchars($this->link)."</id>\n";
         $now = new FeedDate();
-        $feed.= "    <updated>".htmlspecialchars($now->iso8601())."</updated>\n";
-        if ($this->editor!="") {
-            $feed.= "    <author>\n";
-            $feed.= "        <name>".$this->editor."</name>\n";
-            if ($this->editorEmail!="") {
-                $feed.= "        <email>".$this->editorEmail."</email>\n";
+        $feed .= "    <updated>".htmlspecialchars($now->iso8601())."</updated>\n";
+        if ($this->editor != "") {
+            $feed .= "    <author>\n";
+            $feed .= "        <name>".$this->editor."</name>\n";
+            if ($this->editorEmail != "") {
+                $feed .= "        <email>".$this->editorEmail."</email>\n";
             }
-            $feed.= "    </author>\n";
+            $feed .= "    </author>\n";
         }
-        if ($this->category!="") {
+        if ($this->category != "") {
 
-            $feed.= "    <category term=\"" . htmlspecialchars($this->category) . "\" />\n";
+            $feed .= "    <category term=\"".htmlspecialchars($this->category)."\" />\n";
         }
-        if ($this->copyright!="") {
-            $feed.= "    <rights>".FeedCreator::iTrunc(htmlspecialchars($this->copyright),100)."</rights>\n";
+        if ($this->copyright != "") {
+            $feed .= "    <rights>".FeedCreator::iTrunc(htmlspecialchars($this->copyright), 100)."</rights>\n";
         }
-        $feed.= "    <generator>".$this->version()."</generator>\n";
+        $feed .= "    <generator>".$this->version()."</generator>\n";
 
-        $feed.= "    <link rel=\"self\" type=\"application/atom+xml\" href=\"". htmlspecialchars($this->syndicationURL). "\" />\n";
-        $feed.= $this->_createAdditionalElements($this->additionalElements, "    ");
-        for ($i=0;$i<count($this->items);$i++) {
-            $feed.= "    <entry>\n";
-            $feed.= "        <title>".htmlspecialchars(strip_tags($this->items[$i]->title))."</title>\n";
-            $feed.= "        <link rel=\"alternate\" type=\"text/html\" href=\"".htmlspecialchars($this->items[$i]->link)."\"/>\n";
-            if ($this->items[$i]->date=="") {
+        $feed .= "    <link rel=\"self\" type=\"application/atom+xml\" href=\"".htmlspecialchars(
+                $this->syndicationURL
+            )."\" />\n";
+        $feed .= $this->_createAdditionalElements($this->additionalElements, "    ");
+        for ($i = 0; $i < count($this->items); $i++) {
+            $feed .= "    <entry>\n";
+            $feed .= "        <title>".htmlspecialchars(strip_tags($this->items[$i]->title))."</title>\n";
+            $feed .= "        <link rel=\"alternate\" type=\"text/html\" href=\"".htmlspecialchars(
+                    $this->items[$i]->link
+                )."\"/>\n";
+            if ($this->items[$i]->date == "") {
                 $this->items[$i]->date = time();
             }
             $itemDate = new FeedDate($this->items[$i]->date);
-            $feed.= "        <published>".htmlspecialchars($itemDate->iso8601())."</published>\n";
-            $feed.= "        <updated>".htmlspecialchars($itemDate->iso8601())."</updated>\n";
+            $feed .= "        <published>".htmlspecialchars($itemDate->iso8601())."</published>\n";
+            $feed .= "        <updated>".htmlspecialchars($itemDate->iso8601())."</updated>\n";
 
             $tempguid = $this->items[$i]->link;
-            if ($this->items[$i]->guid!="") {
+            if ($this->items[$i]->guid != "") {
                 $tempguid = $this->items[$i]->guid;
             }
 
-            $feed.= "        <id>". htmlspecialchars($tempguid)."</id>\n";
-            $feed.= $this->_createAdditionalElements($this->items[$i]->additionalElements, "        ");
-            if ($this->items[$i]->author!="") {
-                $feed.= "        <author>\n";
-                $feed.= "            <name>".htmlspecialchars($this->items[$i]->author)."</name>\n";
-                if ($this->items[$i]->authorEmail!="") {
-                    $feed.= "            <email>".htmlspecialchars($this->items[$i]->authorEmail)."</email>\n";
+            $feed .= "        <id>".htmlspecialchars($tempguid)."</id>\n";
+            $feed .= $this->_createAdditionalElements($this->items[$i]->additionalElements, "        ");
+            if ($this->items[$i]->author != "") {
+                $feed .= "        <author>\n";
+                $feed .= "            <name>".htmlspecialchars($this->items[$i]->author)."</name>\n";
+                if ($this->items[$i]->authorEmail != "") {
+                    $feed .= "            <email>".htmlspecialchars($this->items[$i]->authorEmail)."</email>\n";
                 }
 
-                if ($this->items[$i]->authorURL!="") {
-                    $feed.= "            <uri>".htmlspecialchars($this->items[$i]->authorURL)."</uri>\n";
+                if ($this->items[$i]->authorURL != "") {
+                    $feed .= "            <uri>".htmlspecialchars($this->items[$i]->authorURL)."</uri>\n";
                 }
 
-                $feed.= "        </author>\n";
+                $feed .= "        </author>\n";
             }
 
-            if ($this->items[$i]->category!="") {
-                $feed.= "        <category ";
+            if ($this->items[$i]->category != "") {
+                $feed .= "        <category ";
 
-                if ($this->items[$i]->categoryScheme!="") {
-                    $feed.=" scheme=\"".htmlspecialchars($this->items[$i]->categoryScheme)."\" ";
+                if ($this->items[$i]->categoryScheme != "") {
+                    $feed .= " scheme=\"".htmlspecialchars($this->items[$i]->categoryScheme)."\" ";
                 }
 
-                $feed.=" term=\"" . htmlspecialchars($this->items[$i]->category) . "\" />\n";
+                $feed .= " term=\"".htmlspecialchars($this->items[$i]->category)."\" />\n";
             }
 
-            if ($this->items[$i]->description!="") {
+            if ($this->items[$i]->description != "") {
 
                 /*
                  * ATOM should have at least summary tag, however this implementation may be inaccurate
                 */
                 $tempdesc = $this->items[$i]->getDescription();
-                $temptype="";
+                $temptype = "";
 
-                if ($this->items[$i]->descriptionHtmlSyndicated){
-                    $temptype=" type=\"html\"";
+                if ($this->items[$i]->descriptionHtmlSyndicated) {
+                    $temptype = " type=\"html\"";
                     $tempdesc = $this->items[$i]->getDescription();
 
                 }
 
                 if (empty($this->items[$i]->descriptionTruncSize)) {
-                    $feed.= "        <content". $temptype . ">". $tempdesc ."</content>\n";
+                    $feed .= "        <content".$temptype.">".$tempdesc."</content>\n";
                 }
 
-                $feed.= "        <summary". $temptype . ">". $tempdesc ."</summary>\n";
+                $feed .= "        <summary".$temptype.">".$tempdesc."</summary>\n";
             } else {
 
-                $feed.= "     <summary>no summary</summary>\n";
+                $feed .= "     <summary>no summary</summary>\n";
 
             }
 
-            if ($this->items[$i]->enclosure != NULL) {
-                $feed.="        <link rel=\"enclosure\" href=\"". $this->items[$i]->enclosure->url ."\" type=\"". $this->items[$i]->enclosure->type."\"  length=\"". $this->items[$i]->enclosure->length ."\"";
+            if ($this->items[$i]->enclosure != null) {
+                $feed .= "        <link rel=\"enclosure\" href=\"".$this->items[$i]->enclosure->url."\" type=\"".$this->items[$i]->enclosure->type."\"  length=\"".$this->items[$i]->enclosure->length."\"";
 
-                if ($this->items[$i]->enclosure->language != ""){
-                    $feed .=" xml:lang=\"". $this->items[$i]->enclosure->language . "\" ";
+                if ($this->items[$i]->enclosure->language != "") {
+                    $feed .= " xml:lang=\"".$this->items[$i]->enclosure->language."\" ";
                 }
 
-                if ($this->items[$i]->enclosure->title != ""){
-                    $feed .=" title=\"". $this->items[$i]->enclosure->title . "\" ";
+                if ($this->items[$i]->enclosure->title != "") {
+                    $feed .= " title=\"".$this->items[$i]->enclosure->title."\" ";
                 }
 
-                $feed .=" /> \n";
+                $feed .= " /> \n";
             }
-            if ($this->items[$i]->lat!="") {
-                $feed.= "        <georss:point>".$this->items[$i]->lat." ".$this->items[$i]->long."</georss:point>\n";
+            if ($this->items[$i]->lat != "") {
+                $feed .= "        <georss:point>".$this->items[$i]->lat." ".$this->items[$i]->long."</georss:point>\n";
             }
-            $feed.= "    </entry>\n";
+            $feed .= "    </entry>\n";
         }
-        $feed.= "</feed>\n";
+        $feed .= "</feed>\n";
+
         return $feed;
     }
 }

--- a/lib/Creator/FeedCreator.php
+++ b/lib/Creator/FeedCreator.php
@@ -1,13 +1,15 @@
 <?php
+
 /**
  * FeedCreator is the abstract base implementation for concrete
  * implementations that implement a specific format of syndication.
  *
- * @author Kai Blankenhorn <kaib@bitfolge.de>
- * @since 1.4
+ * @author  Kai Blankenhorn <kaib@bitfolge.de>
+ * @since   1.4
  * @package de.bitfolge.feedcreator
  */
-abstract class FeedCreator extends HtmlDescribable {
+abstract class FeedCreator extends HtmlDescribable
+{
 
     /**
      * Mandatory attributes of a feed.
@@ -37,13 +39,15 @@ abstract class FeedCreator extends HtmlDescribable {
 
     /**
      * This feed's MIME content type.
-     * @since 1.4
+     *
+     * @since  1.4
      * @access private
      */
     protected $contentType = "application/xml";
 
     /**
      * This feed's character encoding.
+     *
      * @since 1.6.1
      */
     protected $encoding = "UTF-8"; //"ISO-8859-1";
@@ -85,34 +89,35 @@ abstract class FeedCreator extends HtmlDescribable {
      * If the string is truncated, " ..." is appended.
      * If the string is already shorter than $length, it is returned unchanged.
      *
-     * @param string    $string A string to be truncated.
-     * @param int        $length the maximum length the string should be truncated to
-     * @return string    the truncated string
+     * @param string $string A string to be truncated.
+     * @param int $length    the maximum length the string should be truncated to
+     * @return string the truncated string
      */
-    public static function iTrunc($string, $length) {
-        if (strlen($string)<=$length) {
+    public static function iTrunc($string, $length)
+    {
+        if (strlen($string) <= $length) {
             return $string;
         }
 
-        $pos = strrpos($string,".");
-        if ($pos>=$length-4) {
-            $string = substr($string,0,$length-4);
-            $pos = strrpos($string,".");
+        $pos = strrpos($string, ".");
+        if ($pos >= $length - 4) {
+            $string = substr($string, 0, $length - 4);
+            $pos = strrpos($string, ".");
         }
-        if ($pos>=$length*0.4) {
-            return substr($string,0,$pos+1)." ...";
-        }
-
-        $pos = strrpos($string," ");
-        if ($pos>=$length-4) {
-            $string = substr($string,0,$length-4);
-            $pos = strrpos($string," ");
-        }
-        if ($pos>=$length*0.4) {
-            return substr($string,0,$pos)." ...";
+        if ($pos >= $length * 0.4) {
+            return substr($string, 0, $pos + 1)." ...";
         }
 
-        return substr($string,0,$length-4)." ...";
+        $pos = strrpos($string, " ");
+        if ($pos >= $length - 4) {
+            $string = substr($string, 0, $length - 4);
+            $pos = strrpos($string, " ");
+        }
+        if ($pos >= $length * 0.4) {
+            return substr($string, 0, $pos)." ...";
+        }
+
+        return substr($string, 0, $length - 4)." ...";
 
     }
 
@@ -121,60 +126,66 @@ abstract class FeedCreator extends HtmlDescribable {
      * The format of this comment seems to be recognized by
      * Syndic8.com.
      */
-    protected function _createGeneratorComment() {
+    protected function _createGeneratorComment()
+    {
         return "<!-- generator=\"".FEEDCREATOR_VERSION."\" -->\n";
     }
 
     /**
      * Creates a string containing all additional elements specified in
      * $additionalElements.
-     * @param array $elements   an associative array containing key => value pairs
-     * @param string $indentString   a string that will be inserted before every generated line
-     * @return    string    the XML tags corresponding to $additionalElements
+     *
+     * @param array $elements      an associative array containing key => value pairs
+     * @param string $indentString a string that will be inserted before every generated line
+     * @return string the XML tags corresponding to $additionalElements
      */
-    protected function _createAdditionalElements($elements, $indentString="") {
+    protected function _createAdditionalElements($elements, $indentString = "")
+    {
         $ae = "";
         if (is_array($elements)) {
-            foreach($elements AS $key => $value) {
-                $ae.= $indentString."<$key>$value</$key>\n";
+            foreach ($elements AS $key => $value) {
+                $ae .= $indentString."<$key>$value</$key>\n";
             }
         }
+
         return $ae;
     }
 
-    protected function _createStylesheetReferences() {
+    protected function _createStylesheetReferences()
+    {
         $xml = "";
-        if (!empty($this->cssStyleSheet)) $xml .= "<?xml-stylesheet href=\"".$this->cssStyleSheet."\" type=\"text/css\"?>\n";
-        if (!empty($this->xslStyleSheet)) $xml .= "<?xml-stylesheet href=\"".$this->xslStyleSheet."\" type=\"text/xsl\"?>\n";
+        if (!empty($this->cssStyleSheet)) {
+            $xml .= "<?xml-stylesheet href=\"".$this->cssStyleSheet."\" type=\"text/css\"?>\n";
+        }
+        if (!empty($this->xslStyleSheet)) {
+            $xml .= "<?xml-stylesheet href=\"".$this->xslStyleSheet."\" type=\"text/xsl\"?>\n";
+        }
+
         return $xml;
     }
 
     /**
      * Builds the feed's text.
      *
-     * @return    string    the feed's complete text
+     * @return string the feed's complete text
      */
     abstract public function createFeed();
 
     /**
-     * Generate a filename for the feed cache file. The result will be $_SERVER["PHP_SELF"] with the extension changed to .xml.
-     * For example:
-     *
-     * echo $_SERVER["PHP_SELF"]."\n";
-     * echo FeedCreator::_generateFilename();
-     *
-     * would produce:
-     *
+     * Generate a filename for the feed cache file. The result will be $_SERVER["PHP_SELF"] with the extension changed
+     * to .xml. For example: echo $_SERVER["PHP_SELF"]."\n"; echo FeedCreator::_generateFilename(); would produce:
      * /rss/latestnews.php
      * latestnews.xml
      *
      * @return string the feed cache filename
-     * @since 1.4
+     * @since  1.4
      * @access private
      */
-    protected function _generateFilename() {
+    protected function _generateFilename()
+    {
         $fileInfo = pathinfo($_SERVER["PHP_SELF"]);
-        return substr($fileInfo["basename"],0,-(strlen($fileInfo["extension"])+1)).".xml";
+
+        return substr($fileInfo["basename"], 0, -(strlen($fileInfo["extension"]) + 1)).".xml";
     }
 
     /**
@@ -183,7 +194,8 @@ abstract class FeedCreator extends HtmlDescribable {
      * @since 1.4
      * @param string $filename
      */
-    protected function _redirect($filename) {
+    protected function _redirect($filename)
+    {
         // attention, heavily-commented-out-area
 
         // maybe use this in addition to file time checking
@@ -198,7 +210,7 @@ abstract class FeedCreator extends HtmlDescribable {
         //header("Location: ".$filename);
 
         header("Content-Type: ".$this->contentType."; charset=".$this->encoding."; filename=".basename($filename));
-        if (preg_match('/\.(kml|gpx)$/',$filename)) {
+        if (preg_match('/\.(kml|gpx)$/', $filename)) {
             header("Content-Disposition: attachment; filename=".basename($filename));
         } else {
             header("Content-Disposition: inline; filename=".basename($filename));
@@ -213,16 +225,21 @@ abstract class FeedCreator extends HtmlDescribable {
      * To effectively use caching, you should create the FeedCreator object and call this method
      * before anything else, especially before you do the time consuming task to build the feed
      * (web fetching, for example).
+     *
      * @since 1.4
-     * @param string $filename   optional    the filename where a recent version of the feed is saved. If not specified, the filename is $_SERVER["PHP_SELF"] with the extension changed to .xml (see _generateFilename()).
-     * @param int    $timeout    optional    the timeout in seconds before a cached version is refreshed (defaults to 3600 = 1 hour)
+     * @param string $filename optional    the filename where a recent version of the feed is saved. If not specified,
+     *                         the filename is $_SERVER["PHP_SELF"] with the extension changed to .xml (see
+     *                         _generateFilename()).
+     * @param int $timeout     optional    the timeout in seconds before a cached version is refreshed (defaults to
+     *                         3600 = 1 hour)
      */
-    public function useCached($filename="", $timeout=3600) {
+    public function useCached($filename = "", $timeout = 3600)
+    {
         $this->_timeout = $timeout;
-        if ($filename=="") {
+        if ($filename == "") {
             $filename = $this->_generateFilename();
         }
-        if (file_exists($filename) AND (time()-filemtime($filename) < $timeout)) {
+        if (file_exists($filename) AND (time() - filemtime($filename) < $timeout)) {
             $this->_redirect($filename);
         }
     }
@@ -230,18 +247,22 @@ abstract class FeedCreator extends HtmlDescribable {
     /**
      * Saves this feed as a file on the local disk. After the file is saved, a redirect
      * header may be sent to redirect the user to the newly created file.
-     * @since 1.4
      *
-     * @param string $filename   optional    the filename where a recent version of the feed is saved. If not specified, the filename is $_SERVER["PHP_SELF"] with the extension changed to .xml (see _generateFilename()).
-     * @param bool   $displayContents   optional    send an HTTP redirect header or not. If true, the user will be automatically redirected to the created file.
+     * @since 1.4
+     * @param string $filename      optional    the filename where a recent version of the feed is saved. If not
+     *                              specified, the filename is $_SERVER["PHP_SELF"] with the extension changed to .xml
+     *                              (see _generateFilename()).
+     * @param bool $displayContents optional    send an HTTP redirect header or not. If true, the user will be
+     *                              automatically redirected to the created file.
      */
-    public function saveFeed($filename="", $displayContents=true) {
-        if ($filename=="") {
+    public function saveFeed($filename = "", $displayContents = true)
+    {
+        if ($filename == "") {
             $filename = $this->_generateFilename();
         }
         $feedFile = fopen($filename, "w+");
         if ($feedFile) {
-            fputs($feedFile,$this->createFeed());
+            fputs($feedFile, $this->createFeed());
             fclose($feedFile);
             if ($displayContents) {
                 $this->_redirect($filename);

--- a/lib/Creator/GPXCreator.php
+++ b/lib/Creator/GPXCreator.php
@@ -1,45 +1,50 @@
 <?php
+
 /**
  * GPXCreator is a FeedCreator that implements a GPX output, suitable for a GIS packages
  *
- * @since 1.7.6
- * @author Barry Hunter <geo@barryhunter.co.uk>
+ * @since   1.7.6
+ * @author  Barry Hunter <geo@barryhunter.co.uk>
  * @package de.bitfolge.feedcreator
  */
-class GPXCreator extends FeedCreator {
+class GPXCreator extends FeedCreator
+{
 
     /**
      * GPXCreator constructor.
      */
-    public function __construct() {
+    public function __construct()
+    {
         $this->contentType = "text/xml";
         $this->encoding = "utf-8";
     }
 
     /** @inheritdoc */
-    public function createFeed() {
+    public function createFeed()
+    {
         $feed = "<?xml version=\"1.0\" encoding=\"".$this->encoding."\"?>\n";
-        $feed.= $this->_createStylesheetReferences();
-        $feed.= "<gpx xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" version=\"1.0\"
+        $feed .= $this->_createStylesheetReferences();
+        $feed .= "<gpx xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" version=\"1.0\"
         creator=\"".FEEDCREATOR_VERSION."\"
         xsi:schemaLocation=\"http://www.topografix.com/GPX/1/0 http://www.topografix.com/GPX/1/0/gpx.xsd\" xmlns=\"http://www.topografix.com/GPX/1/0\">\n";
 
         $now = new FeedDate();
-        $feed.= "<desc>".FeedCreator::iTrunc(htmlspecialchars($this->title),100)."</desc>
+        $feed .= "<desc>".FeedCreator::iTrunc(htmlspecialchars($this->title), 100)."</desc>
         <author>{$http_host}</author>
         <url>".htmlspecialchars($this->link)."</url>
         <time>".htmlspecialchars($now->iso8601())."</time>
         \n";
 
-        for ($i=0;$i<count($this->items);$i++) {
-            $feed.= "<wpt lat=\"".$this->items[$i]->lat."\" lon=\"".$this->items[$i]->long."\">
-            <name>".substr(htmlspecialchars(strip_tags($this->items[$i]->title)),0,6)."</name>
+        for ($i = 0; $i < count($this->items); $i++) {
+            $feed .= "<wpt lat=\"".$this->items[$i]->lat."\" lon=\"".$this->items[$i]->long."\">
+            <name>".substr(htmlspecialchars(strip_tags($this->items[$i]->title)), 0, 6)."</name>
                 <desc>".htmlspecialchars(strip_tags($this->items[$i]->title))."</desc>
                     <src>".htmlspecialchars($this->items[$i]->author)."</src>
                         <url>".htmlspecialchars($this->items[$i]->link)."</url>
         </wpt>\n";
-    }
-    $feed .= "</gpx>\n";
+        }
+        $feed .= "</gpx>\n";
+
         return $feed;
     }
 }

--- a/lib/Creator/HTMLCreator.php
+++ b/lib/Creator/HTMLCreator.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * HTMLCreator is a FeedCreator that writes an HTML feed file to a specific
  * location, overriding the createFeed method of the parent FeedCreator.
@@ -7,11 +8,12 @@
  * All output by this class is embedded in <div></div> tags to enable formatting
  * using CSS.
  *
- * @author Pascal Van Hecke
- * @since 1.7
+ * @author  Pascal Van Hecke
+ * @since   1.7
  * @package de.bitfolge.feedcreator
  */
-class HTMLCreator extends FeedCreator {
+class HTMLCreator extends FeedCreator
+{
 
     protected $contentType = "text/html";
 
@@ -23,7 +25,7 @@ class HTMLCreator extends FeedCreator {
     /**
      * Contains HTML to be output at the end of the feed's html representation.
      */
-    public $footer ;
+    public $footer;
 
     /**
      * Contains HTML to be output between entries. A separator is only used in
@@ -41,7 +43,7 @@ class HTMLCreator extends FeedCreator {
     public $openInNewWindow = true;
 
     /** @var string image alignments in output */
-    public $imageAlign ="right";
+    public $imageAlign = "right";
 
     /**
      * In case of very simple output you may want to get rid of the style tags,
@@ -50,20 +52,22 @@ class HTMLCreator extends FeedCreator {
      * and when it is non-empty, ONLY the styleless output is printed, the rest is ignored
      * in the function createFeed().
      */
-    public $stylelessOutput ="";
+    public $stylelessOutput = "";
 
     /**
      * Writes the HTML.
+     *
      * @inheritdoc
      */
-    public function createFeed() {
+    public function createFeed()
+    {
         // if there is styleless output, use the content of this variable and ignore the rest
-        if ($this->stylelessOutput!="") {
+        if ($this->stylelessOutput != "") {
             return $this->stylelessOutput;
         }
 
         //if no stylePrefix is set, generate it yourself depending on the script name
-        if ($this->stylePrefix=="") {
+        if ($this->stylePrefix == "") {
             $this->stylePrefix = str_replace(".", "_", $this->_generateFilename())."_";
         }
 
@@ -76,24 +80,24 @@ class HTMLCreator extends FeedCreator {
 
         // use this array to put the lines in and implode later with "document.write" javascript
         $feedArray = array();
-        if ($this->image!=null) {
+        if ($this->image != null) {
             $imageStr = "<a href='".$this->image->link."'".$targetInsert.">".
                 "<img src='".$this->image->url."' border='0' alt='".
-                FeedCreator::iTrunc(htmlspecialchars($this->image->title),100).
+                FeedCreator::iTrunc(htmlspecialchars($this->image->title), 100).
                 "' align='".$this->imageAlign."' ";
             if ($this->image->width) {
-                $imageStr .=" width='".$this->image->width. "' ";
+                $imageStr .= " width='".$this->image->width."' ";
             }
             if ($this->image->height) {
-                $imageStr .=" height='".$this->image->height."' ";
+                $imageStr .= " height='".$this->image->height."' ";
             }
-            $imageStr .="/></a>";
+            $imageStr .= "/></a>";
             $feedArray[] = $imageStr;
         }
 
         if ($this->title) {
             $feedArray[] = "<div class='".$this->stylePrefix."title'><a href='".$this->link."' ".$targetInsert." class='".$this->stylePrefix."title'>".
-                FeedCreator::iTrunc(htmlspecialchars($this->title),100)."</a></div>";
+                FeedCreator::iTrunc(htmlspecialchars($this->title), 100)."</a></div>";
         }
         if ($this->getDescription()) {
             $feedArray[] = "<div class='".$this->stylePrefix."description'>".
@@ -105,7 +109,7 @@ class HTMLCreator extends FeedCreator {
             $feedArray[] = "<div class='".$this->stylePrefix."header'>".$this->header."</div>";
         }
 
-        for ($i=0;$i<count($this->items);$i++) {
+        for ($i = 0; $i < count($this->items); $i++) {
             if ($this->separator and $i > 0) {
                 $feedArray[] = "<div class='".$this->stylePrefix."separator'>".$this->separator."</div>";
             }
@@ -113,28 +117,32 @@ class HTMLCreator extends FeedCreator {
             if ($this->items[$i]->title) {
                 if ($this->items[$i]->link) {
                     $feedArray[] =
-                    "<div class='".$this->stylePrefix."item_title'><a href='".$this->items[$i]->link."' class='".$this->stylePrefix.
-                    "item_title'".$targetInsert.">".FeedCreator::iTrunc(htmlspecialchars(strip_tags($this->items[$i]->title)),100).
-                    "</a></div>";
+                        "<div class='".$this->stylePrefix."item_title'><a href='".$this->items[$i]->link."' class='".$this->stylePrefix.
+                        "item_title'".$targetInsert.">".FeedCreator::iTrunc(
+                            htmlspecialchars(strip_tags($this->items[$i]->title)),
+                            100
+                        ).
+                        "</a></div>";
                 } else {
                     $feedArray[] =
-                    "<div class='".$this->stylePrefix."item_title'>".
-                    FeedCreator::iTrunc(htmlspecialchars(strip_tags($this->items[$i]->title)),100).
-                    "</div>";
+                        "<div class='".$this->stylePrefix."item_title'>".
+                        FeedCreator::iTrunc(htmlspecialchars(strip_tags($this->items[$i]->title)), 100).
+                        "</div>";
                 }
             }
             if ($this->items[$i]->getDescription()) {
                 $feedArray[] =
-                "<div class='".$this->stylePrefix."item_description'>".
-                str_replace("]]>", "", str_replace("<![CDATA[", "", $this->items[$i]->getDescription())).
-                "</div>";
+                    "<div class='".$this->stylePrefix."item_description'>".
+                    str_replace("]]>", "", str_replace("<![CDATA[", "", $this->items[$i]->getDescription())).
+                    "</div>";
             }
         }
         if ($this->footer) {
             $feedArray[] = "<div class='".$this->stylePrefix."footer'>".$this->footer."</div>";
         }
 
-        $feed= "".join($feedArray, "\r\n");
+        $feed = "".join($feedArray, "\r\n");
+
         return $feed;
     }
 
@@ -142,11 +150,13 @@ class HTMLCreator extends FeedCreator {
      * Overrides parent to produce .html extensions
      *
      * @return string the feed cache filename
-     * @since 1.4
+     * @since  1.4
      * @access private
      */
-    protected function _generateFilename() {
+    protected function _generateFilename()
+    {
         $fileInfo = pathinfo($_SERVER["PHP_SELF"]);
-        return substr($fileInfo["basename"],0,-(strlen($fileInfo["extension"])+1)).".html";
+
+        return substr($fileInfo["basename"], 0, -(strlen($fileInfo["extension"]) + 1)).".html";
     }
 }

--- a/lib/Creator/JSCreator.php
+++ b/lib/Creator/JSCreator.php
@@ -1,27 +1,31 @@
 <?php
+
 /**
  * JSCreator is a class that writes a js file to a specific
  * location, overriding the createFeed method of the parent HTMLCreator.
  *
- * @author Pascal Van Hecke
+ * @author  Pascal Van Hecke
  * @package de.bitfolge.feedcreator
  */
-class JSCreator extends HTMLCreator {
+class JSCreator extends HTMLCreator
+{
     protected $contentType = "text/javascript";
 
     /**
      * writes the javascript
+     *
      * @inheritdoc
      */
     public function createFeed()
     {
         $feed = parent::createFeed();
-        $feedArray = explode("\n",$feed);
+        $feedArray = explode("\n", $feed);
 
         $jsFeed = "";
         foreach ($feedArray as $value) {
             $jsFeed .= "document.write('".trim(addslashes($value))."');\n";
         }
+
         return $jsFeed;
     }
 
@@ -29,11 +33,13 @@ class JSCreator extends HTMLCreator {
      * Overrides parent to produce .js extensions
      *
      * @return string the feed cache filename
-     * @since 1.4
+     * @since  1.4
      * @access private
      */
-    protected function _generateFilename() {
+    protected function _generateFilename()
+    {
         $fileInfo = pathinfo($_SERVER["PHP_SELF"]);
-        return substr($fileInfo["basename"],0,-(strlen($fileInfo["extension"])+1)).".js";
+
+        return substr($fileInfo["basename"], 0, -(strlen($fileInfo["extension"]) + 1)).".js";
     }
 }

--- a/lib/Creator/KMLCreator.php
+++ b/lib/Creator/KMLCreator.php
@@ -1,40 +1,45 @@
 <?php
+
 /**
  * KMLCreator is a FeedCreator that implements a KML output, suitable for Keyhole/Google Earth
  *
- * @since 1.7.3
- * @author Barry Hunter <geo@barryhunter.co.uk>
+ * @since   1.7.3
+ * @author  Barry Hunter <geo@barryhunter.co.uk>
  * @package de.bitfolge.feedcreator
  */
-class KMLCreator extends FeedCreator {
+class KMLCreator extends FeedCreator
+{
 
     /**
      * KMLCreator constructor.
      */
-    public function __construct() {
+    public function __construct()
+    {
         $this->contentType = "application/vnd.google-earth.kml+xml";
         $this->encoding = "utf-8";
     }
 
     /** @inheritdoc */
-    public function createFeed() {
+    public function createFeed()
+    {
         $feed = "<?xml version=\"1.0\" encoding=\"".$this->encoding."\"?>\n";
-        $feed.= $this->_createStylesheetReferences();
-        $feed.= "<kml xmlns=\"http://earth.google.com/kml/2.0\">\n";
-        $feed.= "<Document>\n";
-        if ($_GET['LinkControl'])
-            $feed.= "<NetworkLinkControl>\n<minRefreshPeriod>3600</minRefreshPeriod>\n</NetworkLinkControl>\n";
+        $feed .= $this->_createStylesheetReferences();
+        $feed .= "<kml xmlns=\"http://earth.google.com/kml/2.0\">\n";
+        $feed .= "<Document>\n";
+        if ($_GET['LinkControl']) {
+            $feed .= "<NetworkLinkControl>\n<minRefreshPeriod>3600</minRefreshPeriod>\n</NetworkLinkControl>\n";
+        }
         if (!empty($_GET['simple']) && count($this->items) > 0) {
-            $feed.= "<Style id=\"defaultIcon\">
+            $feed .= "<Style id=\"defaultIcon\">
             <LabelStyle>
             <scale>0</scale>
             </LabelStyle>
             </Style>
             <Style id=\"hoverIcon\">".
-            (($this->items[0]->thumb!="")?"
+                (($this->items[0]->thumb != "") ? "
                 <IconStyle id=\"hoverIcon\">
                 <scale>2.1</scale>
-                </IconStyle>":'')."
+                </IconStyle>" : '')."
                 </Style>
                 <StyleMap id=\"defaultStyle\">
                 <Pair>
@@ -51,48 +56,52 @@ class KMLCreator extends FeedCreator {
         } else {
             $style = "root://styleMaps#default?iconId=0x307";
         }
-        $feed.= "<Folder>\n";
-        $feed.= "  <name>".FeedCreator::iTrunc(htmlspecialchars($this->title),100)."</name>
+        $feed .= "<Folder>\n";
+        $feed .= "  <name>".FeedCreator::iTrunc(htmlspecialchars($this->title), 100)."</name>
         <description>".$this->getDescription()."</description>
         <visibility>1</visibility>\n";
         $this->truncSize = 500;
 
-        for ($i=0;$i<count($this->items);$i++) {
+        for ($i = 0; $i < count($this->items); $i++) {
             //added here beucase description gets auto surrounded by cdata
             $this->items[$i]->description = "<b>".$this->items[$i]->description."</b><br/>
             ".$this->items[$i]->licence."
             <br/><br/><a href=\"".htmlspecialchars($this->items[$i]->link)."\">View Online</a>";
 
-            $feed.= "
+            $feed .= "
             <Placemark>
             <description>".$this->items[$i]->getDescription(true)."</description>
-            <name>".FeedCreator::iTrunc(htmlspecialchars(strip_tags($this->items[$i]->title)),100)."</name>
+            <name>".FeedCreator::iTrunc(htmlspecialchars(strip_tags($this->items[$i]->title)), 100)."</name>
             <visibility>1</visibility>
             <Point>
             <coordinates>".$this->items[$i]->long.",".$this->items[$i]->lat.",25</coordinates>
             </Point>";
-            if ($this->items[$i]->thumb!="") {
-                $feed.= "
+            if ($this->items[$i]->thumb != "") {
+                $feed .= "
                 <styleUrl>$style</styleUrl>
                 <Style>
                 <icon>".htmlspecialchars($this->items[$i]->thumb)."</icon>
                     </Style>";
             }
-            $feed.= "
+            $feed .= "
             </Placemark>\n";
-    }
-    $feed .= "</Folder>\n</Document>\n</kml>\n";
-    return $feed;
+        }
+        $feed .= "</Folder>\n</Document>\n</kml>\n";
+
+        return $feed;
     }
 
     /**
      * Generate a filename for the feed cache file. Overridden from FeedCreator to prevent XML data types.
+     *
      * @return string the feed cache filename
-     * @since 1.4
+     * @since  1.4
      * @access private
      */
-     protected function _generateFilename() {
-         $fileInfo = pathinfo($_SERVER["PHP_SELF"]);
-         return substr($fileInfo["basename"],0,-(strlen($fileInfo["extension"])+1)).".kml";
+    protected function _generateFilename()
+    {
+        $fileInfo = pathinfo($_SERVER["PHP_SELF"]);
+
+        return substr($fileInfo["basename"], 0, -(strlen($fileInfo["extension"]) + 1)).".kml";
     }
 }

--- a/lib/Creator/MBOXCreator.php
+++ b/lib/Creator/MBOXCreator.php
@@ -1,18 +1,21 @@
 <?php
+
 /**
  * MBOXCreator is a FeedCreator that implements the mbox format
  * as described in http://www.qmail.org/man/man5/mbox.html
  *
- * @since 1.3
- * @author Kai Blankenhorn <kaib@bitfolge.de>
+ * @since   1.3
+ * @author  Kai Blankenhorn <kaib@bitfolge.de>
  * @package de.bitfolge.feedcreator
  */
-class MBOXCreator extends FeedCreator {
+class MBOXCreator extends FeedCreator
+{
 
     /**
      * MBOXCreator constructor.
      */
-    public function __construct() {
+    public function __construct()
+    {
         $this->contentType = "text/plain";
         $this->encoding = "ISO-8859-15";
     }
@@ -24,25 +27,27 @@ class MBOXCreator extends FeedCreator {
      * @param int $line_max wrap lines after these number of characters
      * @return string
      */
-    protected function qp_enc($input = "", $line_max = 76) {
-        $hex = array('0','1','2','3','4','5','6','7','8','9','A','B','C','D','E','F');
+    protected function qp_enc($input = "", $line_max = 76)
+    {
+        $hex = array('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F');
         $lines = preg_split("/(?:\r\n|\r|\n)/", $input);
         $eol = "\r\n";
         $escape = "=";
         $output = "";
-        foreach($lines as $line) {
+        foreach ($lines as $line) {
             $linlen = strlen($line);
             $newline = "";
-            for($i = 0; $i < $linlen; $i++) {
+            for ($i = 0; $i < $linlen; $i++) {
                 $c = substr($line, $i, 1);
                 $dec = ord($c);
-                if ( ($dec == 32) && ($i == ($linlen - 1)) ) { // convert space at eol only
+                if (($dec == 32) && ($i == ($linlen - 1))) { // convert space at eol only
                     $c = "=20";
-                } elseif ( ($dec == 61) || ($dec < 32 ) || ($dec > 126) ) { // always encode "\t", which is *not* required
-                    $h2 = floor($dec/16); $h1 = floor($dec%16);
+                } elseif (($dec == 61) || ($dec < 32) || ($dec > 126)) { // always encode "\t", which is *not* required
+                    $h2 = floor($dec / 16);
+                    $h1 = floor($dec % 16);
                     $c = $escape.$hex["$h2"].$hex["$h1"];
                 }
-                if ( (strlen($newline) + strlen($c)) >= $line_max ) { // CRLF is not counted
+                if ((strlen($newline) + strlen($c)) >= $line_max) { // CRLF is not counted
                     $output .= $newline.$escape.$eol; // soft line break; " =\r\n" is okay
                     $newline = "";
                 }
@@ -50,47 +55,57 @@ class MBOXCreator extends FeedCreator {
             } // end of for
             $output .= $newline.$eol;
         }
+
         return trim($output);
     }
 
     /**
      * Builds the MBOX contents.
+     *
      * @inheritdoc
      */
-    public function createFeed() {
+    public function createFeed()
+    {
         $feed = '';
-        for ($i=0;$i<count($this->items);$i++) {
-            if ($this->items[$i]->author!="") {
+        for ($i = 0; $i < count($this->items); $i++) {
+            if ($this->items[$i]->author != "") {
                 $from = $this->items[$i]->author;
             } else {
                 $from = $this->title;
             }
             $itemDate = new FeedDate($this->items[$i]->date);
-            $feed.= "From ".strtr(MBOXCreator::qp_enc($from)," ","_")." ".date("D M d H:i:s Y",$itemDate->unix())."\n";
-            $feed.= "Content-Type: text/plain;\n";
-            $feed.= "    charset=\"".$this->encoding."\"\n";
-            $feed.= "Content-Transfer-Encoding: quoted-printable\n";
-            $feed.= "Content-Type: text/plain\n";
-            $feed.= "From: \"".MBOXCreator::qp_enc($from)."\"\n";
-            $feed.= "Date: ".$itemDate->rfc822()."\n";
-            $feed.= "Subject: ".MBOXCreator::qp_enc(FeedCreator::iTrunc($this->items[$i]->title,100))."\n";
-            $feed.= "\n";
+            $feed .= "From ".strtr(MBOXCreator::qp_enc($from), " ", "_")." ".date(
+                    "D M d H:i:s Y",
+                    $itemDate->unix()
+                )."\n";
+            $feed .= "Content-Type: text/plain;\n";
+            $feed .= "    charset=\"".$this->encoding."\"\n";
+            $feed .= "Content-Transfer-Encoding: quoted-printable\n";
+            $feed .= "Content-Type: text/plain\n";
+            $feed .= "From: \"".MBOXCreator::qp_enc($from)."\"\n";
+            $feed .= "Date: ".$itemDate->rfc822()."\n";
+            $feed .= "Subject: ".MBOXCreator::qp_enc(FeedCreator::iTrunc($this->items[$i]->title, 100))."\n";
+            $feed .= "\n";
             $body = chunk_split(MBOXCreator::qp_enc($this->items[$i]->description));
-            $feed.= preg_replace("~\nFrom ([^\n]*)(\n?)~","\n>From $1$2\n",$body);
-            $feed.= "\n";
-            $feed.= "\n";
+            $feed .= preg_replace("~\nFrom ([^\n]*)(\n?)~", "\n>From $1$2\n", $body);
+            $feed .= "\n";
+            $feed .= "\n";
         }
+
         return $feed;
     }
 
     /**
      * Generate a filename for the feed cache file. Overridden from FeedCreator to prevent XML data types.
+     *
      * @return string the feed cache filename
-     * @since 1.4
+     * @since  1.4
      * @access private
      */
-    protected function _generateFilename() {
+    protected function _generateFilename()
+    {
         $fileInfo = pathinfo($_SERVER["PHP_SELF"]);
-        return substr($fileInfo["basename"],0,-(strlen($fileInfo["extension"])+1)).".mbox";
+
+        return substr($fileInfo["basename"], 0, -(strlen($fileInfo["extension"]) + 1)).".mbox";
     }
 }

--- a/lib/Creator/OPMLCreator.php
+++ b/lib/Creator/OPMLCreator.php
@@ -3,64 +3,66 @@
 /**
  * OPMLCreator is a FeedCreator that implements OPML 1.0.
  *
- * @see http://opml.scripting.com/spec
- * @author Dirk Clemens, Kai Blankenhorn
- * @since 1.5
+ * @see     http://opml.scripting.com/spec
+ * @author  Dirk Clemens, Kai Blankenhorn
+ * @since   1.5
  * @package de.bitfolge.feedcreator
  */
-class OPMLCreator extends FeedCreator {
+class OPMLCreator extends FeedCreator
+{
 
     /**
      * OPMLCreator constructor.
      */
-    public function __construct() {
+    public function __construct()
+    {
         $this->encoding = "utf-8";
     }
 
     /** @inheritdoc */
-    public function createFeed() {
+    public function createFeed()
+    {
         $feed = "<?xml version=\"1.0\" encoding=\"".$this->encoding."\"?>\n";
-        $feed.= $this->_createGeneratorComment();
-        $feed.= $this->_createStylesheetReferences();
-        $feed.= "<opml xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n";
-        $feed.= "    <head>\n";
-        $feed.= "        <title>".htmlspecialchars($this->title)."</title>\n";
-        if ($this->pubDate!="") {
+        $feed .= $this->_createGeneratorComment();
+        $feed .= $this->_createStylesheetReferences();
+        $feed .= "<opml xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n";
+        $feed .= "    <head>\n";
+        $feed .= "        <title>".htmlspecialchars($this->title)."</title>\n";
+        if ($this->pubDate != "") {
             $date = new FeedDate($this->pubDate);
-            $feed.= "         <dateCreated>".$date->rfc822()."</dateCreated>\n";
+            $feed .= "         <dateCreated>".$date->rfc822()."</dateCreated>\n";
         }
-        if ($this->lastBuildDate!="") {
+        if ($this->lastBuildDate != "") {
             $date = new FeedDate($this->lastBuildDate);
-            $feed.= "         <dateModified>".$date->rfc822()."</dateModified>\n";
+            $feed .= "         <dateModified>".$date->rfc822()."</dateModified>\n";
         }
-        if ($this->editor!="") {
-            $feed.= "         <ownerName>".$this->editor."</ownerName>\n";
+        if ($this->editor != "") {
+            $feed .= "         <ownerName>".$this->editor."</ownerName>\n";
         }
-        if ($this->editorEmail!="") {
-            $feed.= "         <ownerEmail>".$this->editorEmail."</ownerEmail>\n";
+        if ($this->editorEmail != "") {
+            $feed .= "         <ownerEmail>".$this->editorEmail."</ownerEmail>\n";
         }
-        $feed.= "    </head>\n";
-        $feed.= "    <body>\n";
-        for ($i=0;$i<count($this->items);$i++) {
-            $feed.= "    <outline type=\"rss\" ";
-            $title = htmlspecialchars(strip_tags(strtr($this->items[$i]->title,"\n\r","  ")));
-            $feed.= " title=\"".$title."\"";
-            $feed.= " text=\"".$title."\"";
+        $feed .= "    </head>\n";
+        $feed .= "    <body>\n";
+        for ($i = 0; $i < count($this->items); $i++) {
+            $feed .= "    <outline type=\"rss\" ";
+            $title = htmlspecialchars(strip_tags(strtr($this->items[$i]->title, "\n\r", "  ")));
+            $feed .= " title=\"".$title."\"";
+            $feed .= " text=\"".$title."\"";
 
-            if (isset($this->items[$i]->xmlUrl))
-            {
-                $feed.= " xmlUrl=\"".htmlspecialchars($this->items[$i]->xmlUrl)."\"";
+            if (isset($this->items[$i]->xmlUrl)) {
+                $feed .= " xmlUrl=\"".htmlspecialchars($this->items[$i]->xmlUrl)."\"";
             }
 
-            if (isset($this->items[$i]->link))
-            {
-                $feed.= " url=\"".htmlspecialchars($this->items[$i]->link)."\"";
+            if (isset($this->items[$i]->link)) {
+                $feed .= " url=\"".htmlspecialchars($this->items[$i]->link)."\"";
             }
 
-            $feed.= "/>\n";
+            $feed .= "/>\n";
         }
-        $feed.= "    </body>\n";
-        $feed.= "</opml>\n";
+        $feed .= "    </body>\n";
+        $feed .= "</opml>\n";
+
         return $feed;
     }
 }

--- a/lib/Creator/PHPCreator.php
+++ b/lib/Creator/PHPCreator.php
@@ -1,50 +1,57 @@
 <?php
+
 /**
  * PHPCreator is a FeedCreator that implements a PHP output, suitable for an include
  *
- * @since 1.7.3
- * @author Barry Hunter <geo@barryhunter.co.uk>
+ * @since   1.7.3
+ * @author  Barry Hunter <geo@barryhunter.co.uk>
  * @package de.bitfolge.feedcreator
  */
-class PHPCreator extends FeedCreator {
+class PHPCreator extends FeedCreator
+{
 
     /**
      * PHPCreator constructor.
      */
-    public function __construct() {
+    public function __construct()
+    {
         $this->contentType = "text/plain";
         $this->encoding = "utf-8";
     }
 
     /** @inheritdoc */
-    public function createFeed() {
+    public function createFeed()
+    {
         $feed = "<?php\n";
-        $feed.= "class FeedItem {}\n";
-        $feed.= "  \$feedTitle='".addslashes(FeedCreator::iTrunc(htmlspecialchars($this->title),100))."';\n";
+        $feed .= "class FeedItem {}\n";
+        $feed .= "  \$feedTitle='".addslashes(FeedCreator::iTrunc(htmlspecialchars($this->title), 100))."';\n";
         $this->truncSize = 500;
-        $feed.= "  \$feedDescription='".addslashes($this->getDescription())."';\n";
-        $feed.= "  \$feedLink='".$this->link."';\n";
-        $feed.= "  \$feedItem = array();\n";
-        for ($i=0;$i<count($this->items);$i++) {
-            $feed.= "   \$feedItem[$i] = new FeedItem();\n";
-            if ($this->items[$i]->guid!="") {
-                $feed.= "    \$feedItem[$i]->id='".htmlspecialchars($this->items[$i]->guid)."';\n";
+        $feed .= "  \$feedDescription='".addslashes($this->getDescription())."';\n";
+        $feed .= "  \$feedLink='".$this->link."';\n";
+        $feed .= "  \$feedItem = array();\n";
+        for ($i = 0; $i < count($this->items); $i++) {
+            $feed .= "   \$feedItem[$i] = new FeedItem();\n";
+            if ($this->items[$i]->guid != "") {
+                $feed .= "    \$feedItem[$i]->id='".htmlspecialchars($this->items[$i]->guid)."';\n";
             }
-            $feed.= "    \$feedItem[$i]->title='".addslashes(FeedCreator::iTrunc(htmlspecialchars(strip_tags($this->items[$i]->title)),100))."';\n";
-            $feed.= "    \$feedItem[$i]->link='".htmlspecialchars($this->items[$i]->link)."';\n";
-            $feed.= "    \$feedItem[$i]->date=".htmlspecialchars($this->items[$i]->date).";\n";
-            if ($this->items[$i]->author!="") {
-                $feed.= "    \$feedItem[$i]->author='".htmlspecialchars($this->items[$i]->author)."';\n";
-                if ($this->items[$i]->authorEmail!="") {
-                    $feed.= "    \$feedItem[$i]->authorEmail='".$this->items[$i]->authorEmail."';\n";
+            $feed .= "    \$feedItem[$i]->title='".addslashes(
+                    FeedCreator::iTrunc(htmlspecialchars(strip_tags($this->items[$i]->title)), 100)
+                )."';\n";
+            $feed .= "    \$feedItem[$i]->link='".htmlspecialchars($this->items[$i]->link)."';\n";
+            $feed .= "    \$feedItem[$i]->date=".htmlspecialchars($this->items[$i]->date).";\n";
+            if ($this->items[$i]->author != "") {
+                $feed .= "    \$feedItem[$i]->author='".htmlspecialchars($this->items[$i]->author)."';\n";
+                if ($this->items[$i]->authorEmail != "") {
+                    $feed .= "    \$feedItem[$i]->authorEmail='".$this->items[$i]->authorEmail."';\n";
                 }
             }
-            $feed.= "    \$feedItem[$i]->description='".addslashes($this->items[$i]->getDescription())."';\n";
-            if ($this->items[$i]->thumb!="") {
-                $feed.= "    \$feedItem[$i]->thumbURL='".htmlspecialchars($this->items[$i]->thumb)."';\n";
+            $feed .= "    \$feedItem[$i]->description='".addslashes($this->items[$i]->getDescription())."';\n";
+            if ($this->items[$i]->thumb != "") {
+                $feed .= "    \$feedItem[$i]->thumbURL='".htmlspecialchars($this->items[$i]->thumb)."';\n";
             }
         }
         $feed .= "?>\n";
+
         return $feed;
     }
 }

--- a/lib/Creator/PIECreator01.php
+++ b/lib/Creator/PIECreator01.php
@@ -1,54 +1,63 @@
 <?php
+
 /**
  * PIECreator01 is a FeedCreator that implements the emerging PIE specification,
  * as in http://intertwingly.net/wiki/pie/Syntax.
  *
  * @deprecated
- * @since 1.3
- * @author Scott Reynen <scott@randomchaos.com> and Kai Blankenhorn <kaib@bitfolge.de>
+ * @since   1.3
+ * @author  Scott Reynen <scott@randomchaos.com> and Kai Blankenhorn <kaib@bitfolge.de>
  * @package de.bitfolge.feedcreator
  */
-class PIECreator01 extends FeedCreator {
+class PIECreator01 extends FeedCreator
+{
 
     /**
      * PIECreator01 constructor.
      */
-    public function __construct() {
+    public function __construct()
+    {
         $this->encoding = "utf-8";
     }
 
     /** @inheritdoc */
-    public function createFeed() {
+    public function createFeed()
+    {
         $feed = "<?xml version=\"1.0\" encoding=\"".$this->encoding."\"?>\n";
-        $feed.= $this->_createStylesheetReferences();
-        $feed.= "<feed version=\"0.1\" xmlns=\"http://example.com/newformat#\">\n";
-        $feed.= "    <title>".FeedCreator::iTrunc(htmlspecialchars($this->title),100)."</title>\n";
+        $feed .= $this->_createStylesheetReferences();
+        $feed .= "<feed version=\"0.1\" xmlns=\"http://example.com/newformat#\">\n";
+        $feed .= "    <title>".FeedCreator::iTrunc(htmlspecialchars($this->title), 100)."</title>\n";
         $this->truncSize = 500;
-        $feed.= "    <subtitle>".$this->getDescription()."</subtitle>\n";
-        $feed.= "    <link>".$this->link."</link>\n";
-        for ($i=0;$i<count($this->items);$i++) {
-            $feed.= "    <entry>\n";
-            $feed.= "        <title>".FeedCreator::iTrunc(htmlspecialchars(strip_tags($this->items[$i]->title)),100)."</title>\n";
-            $feed.= "        <link>".htmlspecialchars($this->items[$i]->link)."</link>\n";
+        $feed .= "    <subtitle>".$this->getDescription()."</subtitle>\n";
+        $feed .= "    <link>".$this->link."</link>\n";
+        for ($i = 0; $i < count($this->items); $i++) {
+            $feed .= "    <entry>\n";
+            $feed .= "        <title>".FeedCreator::iTrunc(
+                    htmlspecialchars(strip_tags($this->items[$i]->title)),
+                    100
+                )."</title>\n";
+            $feed .= "        <link>".htmlspecialchars($this->items[$i]->link)."</link>\n";
             $itemDate = new FeedDate($this->items[$i]->date);
-            $feed.= "        <created>".htmlspecialchars($itemDate->iso8601())."</created>\n";
-            $feed.= "        <issued>".htmlspecialchars($itemDate->iso8601())."</issued>\n";
-            $feed.= "        <modified>".htmlspecialchars($itemDate->iso8601())."</modified>\n";
-            $feed.= "        <id>".htmlspecialchars($this->items[$i]->guid)."</id>\n";
-            if ($this->items[$i]->author!="") {
-                $feed.= "        <author>\n";
-                $feed.= "            <name>".htmlspecialchars($this->items[$i]->author)."</name>\n";
-                if ($this->items[$i]->authorEmail!="") {
-                    $feed.= "            <email>".$this->items[$i]->authorEmail."</email>\n";
+            $feed .= "        <created>".htmlspecialchars($itemDate->iso8601())."</created>\n";
+            $feed .= "        <issued>".htmlspecialchars($itemDate->iso8601())."</issued>\n";
+            $feed .= "        <modified>".htmlspecialchars($itemDate->iso8601())."</modified>\n";
+            $feed .= "        <id>".htmlspecialchars($this->items[$i]->guid)."</id>\n";
+            if ($this->items[$i]->author != "") {
+                $feed .= "        <author>\n";
+                $feed .= "            <name>".htmlspecialchars($this->items[$i]->author)."</name>\n";
+                if ($this->items[$i]->authorEmail != "") {
+                    $feed .= "            <email>".$this->items[$i]->authorEmail."</email>\n";
                 }
-                $feed.="        </author>\n";
+                $feed .= "        </author>\n";
             }
-            $feed.= "        <content type=\"text/html\" xml:lang=\"en-us\">\n";
-            $feed.= "            <div xmlns=\"http://www.w3.org/1999/xhtml\">".$this->items[$i]->getDescription()."</div>\n";
-            $feed.= "        </content>\n";
-            $feed.= "    </entry>\n";
+            $feed .= "        <content type=\"text/html\" xml:lang=\"en-us\">\n";
+            $feed .= "            <div xmlns=\"http://www.w3.org/1999/xhtml\">".$this->items[$i]->getDescription(
+                )."</div>\n";
+            $feed .= "        </content>\n";
+            $feed .= "    </entry>\n";
         }
-        $feed.= "</feed>\n";
+        $feed .= "</feed>\n";
+
         return $feed;
     }
 }

--- a/lib/Creator/RSSCreator091.php
+++ b/lib/Creator/RSSCreator091.php
@@ -1,13 +1,15 @@
 <?php
+
 /**
  * RSSCreator091 is a FeedCreator that implements RSS 0.91 Spec, revision 3.
  *
- * @see http://my.netscape.com/publish/formats/rss-spec-0.91.html
- * @since 1.3
- * @author Kai Blankenhorn <kaib@bitfolge.de>
+ * @see     http://my.netscape.com/publish/formats/rss-spec-0.91.html
+ * @since   1.3
+ * @author  Kai Blankenhorn <kaib@bitfolge.de>
  * @package de.bitfolge.feedcreator
  */
-class RSSCreator091 extends FeedCreator {
+class RSSCreator091 extends FeedCreator
+{
 
     /** @var string Stores this RSS feed's version number. */
     protected $RSSVersion;
@@ -15,112 +17,129 @@ class RSSCreator091 extends FeedCreator {
     /**
      * RSSCreator091 constructor.
      */
-    function __construct() {
+    function __construct()
+    {
         $this->_setRSSVersion("0.91");
         $this->contentType = "application/rss+xml";
     }
 
     /**
      * Sets this RSS feed's version number.
+     *
      * @param string $version
      */
-    protected function _setRSSVersion($version) {
+    protected function _setRSSVersion($version)
+    {
         $this->RSSVersion = $version;
     }
 
     /** @inheritdoc */
-    public function createFeed() {
+    public function createFeed()
+    {
         $feed = "<?xml version=\"1.0\" encoding=\"".$this->encoding."\"?>\n";
-        $feed.= $this->_createGeneratorComment();
-        $feed.= $this->_createStylesheetReferences();
-        $feed.= "<rss version=\"".$this->RSSVersion."\"";
+        $feed .= $this->_createGeneratorComment();
+        $feed .= $this->_createStylesheetReferences();
+        $feed .= "<rss version=\"".$this->RSSVersion."\"";
 
-        if (   count($this->items) > 0
-            && !empty($this->items[0]->lat))
-        {
-            $feed.= "    xmlns:georss=\"http://www.georss.org/georss/\"\n";
+        if (count($this->items) > 0
+            && !empty($this->items[0]->lat)
+        ) {
+            $feed .= "    xmlns:georss=\"http://www.georss.org/georss/\"\n";
         }
-        if (   count($this->items) > 0
-            && isset($this->items[0]->additionalElements['xcal:dtstart']))
-        {
-            $feed.= "    xmlns:xcal=\"urn:ietf:params:xml:ns:xcal\"\n";
+        if (count($this->items) > 0
+            && isset($this->items[0]->additionalElements['xcal:dtstart'])
+        ) {
+            $feed .= "    xmlns:xcal=\"urn:ietf:params:xml:ns:xcal\"\n";
         }
-        $feed.= ">\n";
+        $feed .= ">\n";
         if ($this->format == 'BASE') {
-            $feed.= "    <channel xmlns:g=\"http://base.google.com/ns/1.0\">\n";
+            $feed .= "    <channel xmlns:g=\"http://base.google.com/ns/1.0\">\n";
         } else {
-            $feed.= "    <channel>\n";
+            $feed .= "    <channel>\n";
         }
-        $feed.= "        <title>".FeedCreator::iTrunc(htmlspecialchars($this->title),100)."</title>\n";
+        $feed .= "        <title>".FeedCreator::iTrunc(htmlspecialchars($this->title), 100)."</title>\n";
         $this->descriptionTruncSize = 500;
-        $feed.= "        <description>".$this->getDescription()."</description>\n";
-        $feed.= "        <link>".$this->link."</link>\n";
+        $feed .= "        <description>".$this->getDescription()."</description>\n";
+        $feed .= "        <link>".$this->link."</link>\n";
         $now = new FeedDate();
-        $feed.= "        <lastBuildDate>".htmlspecialchars($this->lastBuildDate ?: $now->rfc822())."</lastBuildDate>\n";
-        $feed.= "        <generator>".FEEDCREATOR_VERSION."</generator>\n";
+        $feed .= "        <lastBuildDate>".htmlspecialchars(
+                $this->lastBuildDate ?: $now->rfc822()
+            )."</lastBuildDate>\n";
+        $feed .= "        <generator>".FEEDCREATOR_VERSION."</generator>\n";
 
-        if ($this->image!=null) {
-            $feed.= "        <image>\n";
-            $feed.= "            <url>".$this->image->url."</url>\n";
-            $feed.= "            <title>".FeedCreator::iTrunc(htmlspecialchars($this->image->title),100)."</title>\n";
-            $feed.= "            <link>".$this->image->link."</link>\n";
-            if ($this->image->width!="") {
-                $feed.= "            <width>".$this->image->width."</width>\n";
+        if ($this->image != null) {
+            $feed .= "        <image>\n";
+            $feed .= "            <url>".$this->image->url."</url>\n";
+            $feed .= "            <title>".FeedCreator::iTrunc(htmlspecialchars($this->image->title), 100)."</title>\n";
+            $feed .= "            <link>".$this->image->link."</link>\n";
+            if ($this->image->width != "") {
+                $feed .= "            <width>".$this->image->width."</width>\n";
             }
-            if ($this->image->height!="") {
-                $feed.= "            <height>".$this->image->height."</height>\n";
+            if ($this->image->height != "") {
+                $feed .= "            <height>".$this->image->height."</height>\n";
             }
-            if ($this->image->description!="") {
-                $feed.= "            <description>".htmlspecialchars($this->image->description)."</description>\n";
+            if ($this->image->description != "") {
+                $feed .= "            <description>".htmlspecialchars($this->image->description)."</description>\n";
             }
-            $feed.= "        </image>\n";
+            $feed .= "        </image>\n";
         }
-        if ($this->language!="") {
-            $feed.= "        <language>".$this->language."</language>\n";
+        if ($this->language != "") {
+            $feed .= "        <language>".$this->language."</language>\n";
         }
-        if ($this->copyright!="") {
-            $feed.= "        <copyright>".FeedCreator::iTrunc(htmlspecialchars($this->copyright),100)."</copyright>\n";
+        if ($this->copyright != "") {
+            $feed .= "        <copyright>".FeedCreator::iTrunc(
+                    htmlspecialchars($this->copyright),
+                    100
+                )."</copyright>\n";
         }
-        if ($this->editor!="") {
-            $feed.= "        <managingEditor>".FeedCreator::iTrunc(htmlspecialchars($this->editor),100)."</managingEditor>\n";
+        if ($this->editor != "") {
+            $feed .= "        <managingEditor>".FeedCreator::iTrunc(
+                    htmlspecialchars($this->editor),
+                    100
+                )."</managingEditor>\n";
         }
-        if ($this->webmaster!="") {
-            $feed.= "        <webMaster>".FeedCreator::iTrunc(htmlspecialchars($this->webmaster),100)."</webMaster>\n";
+        if ($this->webmaster != "") {
+            $feed .= "        <webMaster>".FeedCreator::iTrunc(
+                    htmlspecialchars($this->webmaster),
+                    100
+                )."</webMaster>\n";
         }
-        if ($this->pubDate!="") {
+        if ($this->pubDate != "") {
             $pubDate = new FeedDate($this->pubDate);
-            $feed.= "        <pubDate>".htmlspecialchars($pubDate->rfc822())."</pubDate>\n";
+            $feed .= "        <pubDate>".htmlspecialchars($pubDate->rfc822())."</pubDate>\n";
         }
-        if ($this->category!="") {
-            $feed.= "        <category>".htmlspecialchars($this->category)."</category>\n";
+        if ($this->category != "") {
+            $feed .= "        <category>".htmlspecialchars($this->category)."</category>\n";
         }
-        if ($this->docs!="") {
-            $feed.= "        <docs>".FeedCreator::iTrunc(htmlspecialchars($this->docs),500)."</docs>\n";
+        if ($this->docs != "") {
+            $feed .= "        <docs>".FeedCreator::iTrunc(htmlspecialchars($this->docs), 500)."</docs>\n";
         }
-        if ($this->ttl!="") {
-            $feed.= "        <ttl>".htmlspecialchars($this->ttl)."</ttl>\n";
+        if ($this->ttl != "") {
+            $feed .= "        <ttl>".htmlspecialchars($this->ttl)."</ttl>\n";
         }
-        if ($this->rating!="") {
-            $feed.= "        <rating>".FeedCreator::iTrunc(htmlspecialchars($this->rating),500)."</rating>\n";
+        if ($this->rating != "") {
+            $feed .= "        <rating>".FeedCreator::iTrunc(htmlspecialchars($this->rating), 500)."</rating>\n";
         }
-        if ($this->skipHours!="") {
-            $feed.= "        <skipHours>".htmlspecialchars($this->skipHours)."</skipHours>\n";
+        if ($this->skipHours != "") {
+            $feed .= "        <skipHours>".htmlspecialchars($this->skipHours)."</skipHours>\n";
         }
-        if ($this->skipDays!="") {
-            $feed.= "        <skipDays>".htmlspecialchars($this->skipDays)."</skipDays>\n";
+        if ($this->skipDays != "") {
+            $feed .= "        <skipDays>".htmlspecialchars($this->skipDays)."</skipDays>\n";
         }
-        $feed.= $this->_createAdditionalElements($this->additionalElements, "    ");
+        $feed .= $this->_createAdditionalElements($this->additionalElements, "    ");
 
-        for ($i=0;$i<count($this->items);$i++)
-        {
-            $feed.= "        <item>\n";
-            $feed.= "            <title>".FeedCreator::iTrunc(htmlspecialchars(strip_tags($this->items[$i]->title)),100)."</title>\n";
-            $feed.= "            <link>".htmlspecialchars($this->items[$i]->link)."</link>\n";
-            $feed.= "            <description>".$this->items[$i]->getDescription()."</description>\n";
+        for ($i = 0; $i < count($this->items); $i++) {
+            $feed .= "        <item>\n";
+            $feed .= "            <title>".FeedCreator::iTrunc(
+                    htmlspecialchars(strip_tags($this->items[$i]->title)),
+                    100
+                )."</title>\n";
+            $feed .= "            <link>".htmlspecialchars($this->items[$i]->link)."</link>\n";
+            $feed .= "            <description>".$this->items[$i]->getDescription()."</description>\n";
 
             $creator = $this->getAuthor($this->items[$i]->author, $this->items[$i]->authorEmail);
             if ($creator) {
-                $feed .= "            <author>" . htmlspecialchars($creator) . "</author>\n";
+                $feed .= "            <author>".htmlspecialchars($creator)."</author>\n";
             }
 
             /*
@@ -129,32 +148,37 @@ class RSSCreator091 extends FeedCreator {
             $feed.= "            <source>".htmlspecialchars($this->items[$i]->source)."</source>\n";
             }
             */
-            if ($this->items[$i]->lat!="") {
-                $feed.= "            <georss:point>".$this->items[$i]->lat." ".$this->items[$i]->long."</georss:point>\n";
+            if ($this->items[$i]->lat != "") {
+                $feed .= "            <georss:point>".$this->items[$i]->lat." ".$this->items[$i]->long."</georss:point>\n";
             }
-            if(is_array($this->items[$i]->category)) foreach($this->items[$i]->category as $cat){
-                $feed.= "        <category>".htmlspecialchars($cat)."</category>\n";
-            }else if($this->items[$i]->category!=""){
-                $feed.= "        <category>".htmlspecialchars($this->items[$i]->category)."</category>\n";
+            if (is_array($this->items[$i]->category)) {
+                foreach ($this->items[$i]->category as $cat) {
+                    $feed .= "        <category>".htmlspecialchars($cat)."</category>\n";
+                }
+            } else {
+                if ($this->items[$i]->category != "") {
+                    $feed .= "        <category>".htmlspecialchars($this->items[$i]->category)."</category>\n";
+                }
             }
-            if ($this->items[$i]->comments!="") {
-                $feed.= "            <comments>".htmlspecialchars($this->items[$i]->comments)."</comments>\n";
+            if ($this->items[$i]->comments != "") {
+                $feed .= "            <comments>".htmlspecialchars($this->items[$i]->comments)."</comments>\n";
             }
-            if ($this->items[$i]->date!="") {
+            if ($this->items[$i]->date != "") {
                 $itemDate = new FeedDate($this->items[$i]->date);
-                $feed.= "            <pubDate>".htmlspecialchars($itemDate->rfc822())."</pubDate>\n";
+                $feed .= "            <pubDate>".htmlspecialchars($itemDate->rfc822())."</pubDate>\n";
             }
-            if ($this->items[$i]->guid!="") {
-                $feed.= "            <guid>".htmlspecialchars($this->items[$i]->guid)."</guid>\n";
+            if ($this->items[$i]->guid != "") {
+                $feed .= "            <guid>".htmlspecialchars($this->items[$i]->guid)."</guid>\n";
             }
-            if ($this->items[$i]->thumb!="") {
-                $feed.= "            <g:image_link>".htmlspecialchars($this->items[$i]->thumb)."</g:image_link>\n";
+            if ($this->items[$i]->thumb != "") {
+                $feed .= "            <g:image_link>".htmlspecialchars($this->items[$i]->thumb)."</g:image_link>\n";
             }
-            $feed.= $this->_createAdditionalElements($this->items[$i]->additionalElements, "            ");
-            $feed.= "        </item>\n";
+            $feed .= $this->_createAdditionalElements($this->items[$i]->additionalElements, "            ");
+            $feed .= "        </item>\n";
         }
-        $feed.= "    </channel>\n";
-        $feed.= "</rss>\n";
+        $feed .= "    </channel>\n";
+        $feed .= "</rss>\n";
+
         return $feed;
     }
 
@@ -163,10 +187,12 @@ class RSSCreator091 extends FeedCreator {
      *
      * @author Joe Lapp <joe.lapp@pobox.com>
      */
-    function getAuthor($author, $email) {
+    function getAuthor($author, $email)
+    {
         if ($author && $email) {
-            return $email . ' (' . $author . ')';
+            return $email.' ('.$author.')';
         }
+
         return $email;
     }
 }

--- a/lib/Creator/RSSCreator10.php
+++ b/lib/Creator/RSSCreator10.php
@@ -1,88 +1,92 @@
 <?php
+
 /**
  * RSSCreator10 is a FeedCreator that implements RDF Site Summary (RSS) 1.0.
  *
- * @see http://www.purl.org/rss/1.0/
- * @since 1.3
- * @author Kai Blankenhorn <kaib@bitfolge.de>
+ * @see     http://www.purl.org/rss/1.0/
+ * @since   1.3
+ * @author  Kai Blankenhorn <kaib@bitfolge.de>
  * @package de.bitfolge.feedcreator
  */
-class RSSCreator10 extends FeedCreator {
+class RSSCreator10 extends FeedCreator
+{
 
     /** @inheritdoc */
-    public function createFeed() {
+    public function createFeed()
+    {
         $feed = "<?xml version=\"1.0\" encoding=\"".$this->encoding."\"?>\n";
-        $feed.= $this->_createGeneratorComment();
+        $feed .= $this->_createGeneratorComment();
         if (empty($this->cssStyleSheet)) {
             $this->cssStyleSheet = "http://www.w3.org/2000/08/w3c-synd/style.css";
         }
-        $feed.= $this->_createStylesheetReferences();
-        $feed.= "<rdf:RDF\n";
-        $feed.= "    xmlns=\"http://purl.org/rss/1.0/\"\n";
-        $feed.= "    xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\"\n";
-        $feed.= "    xmlns:slash=\"http://purl.org/rss/1.0/modules/slash/\"\n";
-        if (!empty($this->items[0]->thumb))
-        {
-            $feed.= "    xmlns:photo=\"http://www.pheed.com/pheed/\"\n";
+        $feed .= $this->_createStylesheetReferences();
+        $feed .= "<rdf:RDF\n";
+        $feed .= "    xmlns=\"http://purl.org/rss/1.0/\"\n";
+        $feed .= "    xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\"\n";
+        $feed .= "    xmlns:slash=\"http://purl.org/rss/1.0/modules/slash/\"\n";
+        if (!empty($this->items[0]->thumb)) {
+            $feed .= "    xmlns:photo=\"http://www.pheed.com/pheed/\"\n";
         }
-        if (!empty($this->items[0]->lat))
-        {
-            $feed.= "    xmlns:georss=\"http://www.georss.org/georss\"\n";
+        if (!empty($this->items[0]->lat)) {
+            $feed .= "    xmlns:georss=\"http://www.georss.org/georss\"\n";
         }
-        $feed.= "    xmlns:dc=\"http://purl.org/dc/elements/1.1/\">\n";
-        $feed.= "    <channel rdf:about=\"".$this->syndicationURL."\">\n";
-        $feed.= "        <title>".htmlspecialchars($this->title)."</title>\n";
-        $feed.= "        <description>".htmlspecialchars($this->description)."</description>\n";
-        $feed.= "        <link>".$this->link."</link>\n";
-        if ($this->image!=null) {
-            $feed.= "        <image rdf:resource=\"".$this->image->url."\" />\n";
+        $feed .= "    xmlns:dc=\"http://purl.org/dc/elements/1.1/\">\n";
+        $feed .= "    <channel rdf:about=\"".$this->syndicationURL."\">\n";
+        $feed .= "        <title>".htmlspecialchars($this->title)."</title>\n";
+        $feed .= "        <description>".htmlspecialchars($this->description)."</description>\n";
+        $feed .= "        <link>".$this->link."</link>\n";
+        if ($this->image != null) {
+            $feed .= "        <image rdf:resource=\"".$this->image->url."\" />\n";
         }
         $now = new FeedDate();
-        $feed.= "       <dc:date>".htmlspecialchars($now->iso8601())."</dc:date>\n";
-        $feed.= "        <items>\n";
-        $feed.= "            <rdf:Seq>\n";
-        for ($i=0;$i<count($this->items);$i++) {
-            $feed.= "                <rdf:li rdf:resource=\"".htmlspecialchars($this->items[$i]->link)."\"/>\n";
+        $feed .= "       <dc:date>".htmlspecialchars($now->iso8601())."</dc:date>\n";
+        $feed .= "        <items>\n";
+        $feed .= "            <rdf:Seq>\n";
+        for ($i = 0; $i < count($this->items); $i++) {
+            $feed .= "                <rdf:li rdf:resource=\"".htmlspecialchars($this->items[$i]->link)."\"/>\n";
         }
-        $feed.= "            </rdf:Seq>\n";
-        $feed.= "        </items>\n";
-        $feed.= "    </channel>\n";
-        if ($this->image!=null) {
-            $feed.= "    <image rdf:about=\"".$this->image->url."\">\n";
-            $feed.= "        <title>".$this->image->title."</title>\n";
-            $feed.= "        <link>".$this->image->link."</link>\n";
-            $feed.= "        <url>".$this->image->url."</url>\n";
-            $feed.= "    </image>\n";
+        $feed .= "            </rdf:Seq>\n";
+        $feed .= "        </items>\n";
+        $feed .= "    </channel>\n";
+        if ($this->image != null) {
+            $feed .= "    <image rdf:about=\"".$this->image->url."\">\n";
+            $feed .= "        <title>".$this->image->title."</title>\n";
+            $feed .= "        <link>".$this->image->link."</link>\n";
+            $feed .= "        <url>".$this->image->url."</url>\n";
+            $feed .= "    </image>\n";
         }
-        $feed.= $this->_createAdditionalElements($this->additionalElements, "    ");
+        $feed .= $this->_createAdditionalElements($this->additionalElements, "    ");
 
-        for ($i=0;$i<count($this->items);$i++) {
-            $feed.= "    <item rdf:about=\"".htmlspecialchars($this->items[$i]->link)."\">\n";
-            $feed.= "        <dc:format>text/html</dc:format>\n";
-            if ($this->items[$i]->date!=null) {
+        for ($i = 0; $i < count($this->items); $i++) {
+            $feed .= "    <item rdf:about=\"".htmlspecialchars($this->items[$i]->link)."\">\n";
+            $feed .= "        <dc:format>text/html</dc:format>\n";
+            if ($this->items[$i]->date != null) {
                 $itemDate = new FeedDate($this->items[$i]->date);
-                $feed.= "        <dc:date>".htmlspecialchars($itemDate->iso8601())."</dc:date>\n";
+                $feed .= "        <dc:date>".htmlspecialchars($itemDate->iso8601())."</dc:date>\n";
             }
-            if ($this->items[$i]->source!="") {
-                $feed.= "        <dc:source>".htmlspecialchars($this->items[$i]->source)."</dc:source>\n";
+            if ($this->items[$i]->source != "") {
+                $feed .= "        <dc:source>".htmlspecialchars($this->items[$i]->source)."</dc:source>\n";
             }
             $creator = $this->getAuthor($this->items[$i]->author, $this->items[$i]->authorEmail);
             if ($creator) {
-                $feed.= "        <dc:creator>".htmlspecialchars($creator)."</dc:creator>\n";
+                $feed .= "        <dc:creator>".htmlspecialchars($creator)."</dc:creator>\n";
             }
-            if ($this->items[$i]->lat!="") {
-                $feed.= "        <georss:point>".$this->items[$i]->lat." ".$this->items[$i]->long."</georss:point>\n";
+            if ($this->items[$i]->lat != "") {
+                $feed .= "        <georss:point>".$this->items[$i]->lat." ".$this->items[$i]->long."</georss:point>\n";
             }
-            if ($this->items[$i]->thumb!="") {
-                $feed.= "        <photo:thumbnail>".htmlspecialchars($this->items[$i]->thumb)."</photo:thumbnail>\n";
+            if ($this->items[$i]->thumb != "") {
+                $feed .= "        <photo:thumbnail>".htmlspecialchars($this->items[$i]->thumb)."</photo:thumbnail>\n";
             }
-            $feed.= "        <title>".htmlspecialchars(strip_tags(strtr($this->items[$i]->title,"\n\r","  ")))."</title>\n";
-            $feed.= "        <link>".htmlspecialchars($this->items[$i]->link)."</link>\n";
-            $feed.= "        <description>".htmlspecialchars($this->items[$i]->description)."</description>\n";
-            $feed.= $this->_createAdditionalElements($this->items[$i]->additionalElements, "        ");
-            $feed.= "    </item>\n";
+            $feed .= "        <title>".htmlspecialchars(
+                    strip_tags(strtr($this->items[$i]->title, "\n\r", "  "))
+                )."</title>\n";
+            $feed .= "        <link>".htmlspecialchars($this->items[$i]->link)."</link>\n";
+            $feed .= "        <description>".htmlspecialchars($this->items[$i]->description)."</description>\n";
+            $feed .= $this->_createAdditionalElements($this->items[$i]->additionalElements, "        ");
+            $feed .= "    </item>\n";
         }
-        $feed.= "</rdf:RDF>\n";
+        $feed .= "</rdf:RDF>\n";
+
         return $feed;
     }
 
@@ -94,13 +98,16 @@ class RSSCreator10 extends FeedCreator {
      * @param string $email
      * @return string
      */
-    protected function getAuthor($author, $email) {
+    protected function getAuthor($author, $email)
+    {
         if ($author) {
             if ($email) {
-                return $author . ' (' . $email . ')';
+                return $author.' ('.$email.')';
             }
+
             return $author;
         }
+
         return $email;
     }
 }

--- a/lib/Creator/RSSCreator20.php
+++ b/lib/Creator/RSSCreator20.php
@@ -1,18 +1,21 @@
 <?php
+
 /**
  * RSSCreator20 is a FeedCreator that implements RDF Site Summary (RSS) 2.0.
  *
- * @see http://backend.userland.com/rss
- * @since 1.3
- * @author Kai Blankenhorn <kaib@bitfolge.de>
+ * @see     http://backend.userland.com/rss
+ * @since   1.3
+ * @author  Kai Blankenhorn <kaib@bitfolge.de>
  * @package de.bitfolge.feedcreator
  */
-class RSSCreator20 extends RSSCreator091 {
+class RSSCreator20 extends RSSCreator091
+{
 
     /**
      * RSSCreator20 constructor.
      */
-    public function __construct() {
+    public function __construct()
+    {
         parent::__construct();
         parent::_setRSSVersion("2.0");
     }

--- a/lib/Element/FeedDate.php
+++ b/lib/Element/FeedDate.php
@@ -1,62 +1,89 @@
 <?php
+
 /**
  * FeedDate is an internal class that stores a date for a feed or feed item.
  * Usually, you won't need to use this.
  *
  * @package de.bitfolge.feedcreator
  */
-class FeedDate {
+class FeedDate
+{
     protected $unix;
 
     /**
      * Creates a new instance of FeedDate representing a given date.
      * Accepts RFC 822, ISO 8601 date formats as well as unix time stamps.
      *
-     * @param mixed $dateString optional the date this FeedDate will represent. If not specified, the current date and time is used.
+     * @param mixed $dateString optional the date this FeedDate will represent. If not specified, the current date and
+     *                          time is used.
      */
-    public function __construct($dateString="") {
-        if ($dateString=="") $dateString = date("r");
+    public function __construct($dateString = "")
+    {
+        if ($dateString == "") {
+            $dateString = date("r");
+        }
 
         if (is_integer($dateString)) {
             $this->unix = $dateString;
+
             return;
         }
         $tzOffset = 0;
-        if (preg_match("~(?:(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun),\\s+)?(\\d{1,2})\\s+([a-zA-Z]{3})\\s+(\\d{4})\\s+(\\d{2}):(\\d{2}):(\\d{2})\\s+(.*)~",$dateString,$matches)) {
-            $months = Array("Jan"=>1,"Feb"=>2,"Mar"=>3,"Apr"=>4,"May"=>5,"Jun"=>6,"Jul"=>7,"Aug"=>8,"Sep"=>9,"Oct"=>10,"Nov"=>11,"Dec"=>12);
-            $this->unix = mktime($matches[4],$matches[5],$matches[6],$months[$matches[2]],$matches[1],$matches[3]);
-            if (substr($matches[7],0,1)=='+' OR substr($matches[7],0,1)=='-') {
+        if (preg_match(
+            "~(?:(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun),\\s+)?(\\d{1,2})\\s+([a-zA-Z]{3})\\s+(\\d{4})\\s+(\\d{2}):(\\d{2}):(\\d{2})\\s+(.*)~",
+            $dateString,
+            $matches
+        )) {
+            $months = Array(
+                "Jan" => 1,
+                "Feb" => 2,
+                "Mar" => 3,
+                "Apr" => 4,
+                "May" => 5,
+                "Jun" => 6,
+                "Jul" => 7,
+                "Aug" => 8,
+                "Sep" => 9,
+                "Oct" => 10,
+                "Nov" => 11,
+                "Dec" => 12,
+            );
+            $this->unix = mktime($matches[4], $matches[5], $matches[6], $months[$matches[2]], $matches[1], $matches[3]);
+            if (substr($matches[7], 0, 1) == '+' OR substr($matches[7], 0, 1) == '-') {
                 $tzOffset = (((int)substr($matches[7], 0, 3) * 60) + (int)substr($matches[7], -2)) * 60;
             } else {
-                if (strlen($matches[7])==1) {
+                if (strlen($matches[7]) == 1) {
                     $oneHour = 3600;
                     $ord = ord($matches[7]);
                     if ($ord < ord("M")) {
                         $tzOffset = (ord("A") - $ord - 1) * $oneHour;
-                    } elseif ($ord >= ord("M") AND $matches[7]!="Z") {
+                    } elseif ($ord >= ord("M") AND $matches[7] != "Z") {
                         $tzOffset = ($ord - ord("M")) * $oneHour;
-                    } elseif ($matches[7]=="Z") {
+                    } elseif ($matches[7] == "Z") {
                         $tzOffset = 0;
                     }
                 }
                 switch ($matches[7]) {
                     case "UT":
-                    case "GMT":    $tzOffset = 0;
+                    case "GMT":
+                        $tzOffset = 0;
                 }
             }
             $this->unix += $tzOffset;
+
             return;
         }
-        if (preg_match("~(\\d{4})-(\\d{2})-(\\d{2})T(\\d{2}):(\\d{2}):(\\d{2})(.*)~",$dateString,$matches)) {
-            $this->unix = mktime($matches[4],$matches[5],$matches[6],$matches[2],$matches[3],$matches[1]);
-            if (substr($matches[7],0,1)=='+' OR substr($matches[7],0,1)=='-') {
-                $tzOffset = (((int) substr($matches[7],0,3) * 60) + (int)substr($matches[7], -2)) * 60;
+        if (preg_match("~(\\d{4})-(\\d{2})-(\\d{2})T(\\d{2}):(\\d{2}):(\\d{2})(.*)~", $dateString, $matches)) {
+            $this->unix = mktime($matches[4], $matches[5], $matches[6], $matches[2], $matches[3], $matches[1]);
+            if (substr($matches[7], 0, 1) == '+' OR substr($matches[7], 0, 1) == '-') {
+                $tzOffset = (((int)substr($matches[7], 0, 3) * 60) + (int)substr($matches[7], -2)) * 60;
             } else {
-                if ($matches[7]=="Z") {
+                if ($matches[7] == "Z") {
                     $tzOffset = 0;
                 }
             }
             $this->unix += $tzOffset;
+
             return;
         }
         $this->unix = 0;
@@ -67,9 +94,11 @@ class FeedDate {
      *
      * @return string a date in RFC 822 format
      */
-    public function rfc822() {
+    public function rfc822()
+    {
         //return gmdate("r",$this->unix);
         $date = gmdate("D, d M Y H:i:s O", $this->unix);
+
         return $date;
     }
 
@@ -78,10 +107,14 @@ class FeedDate {
      *
      * @return string a date in ISO 8601 format
      */
-    public function iso8601() {
-        $date = gmdate("Y-m-d\TH:i:sO",$this->unix);
-        $date = substr($date,0,22) . ':' . substr($date,-2);
-        if (TIME_ZONE!="") $date = str_replace("+00:00",TIME_ZONE,$date);
+    public function iso8601()
+    {
+        $date = gmdate("Y-m-d\TH:i:sO", $this->unix);
+        $date = substr($date, 0, 22).':'.substr($date, -2);
+        if (TIME_ZONE != "") {
+            $date = str_replace("+00:00", TIME_ZONE, $date);
+        }
+
         return $date;
     }
 
@@ -90,7 +123,8 @@ class FeedDate {
      *
      * @return int a date as a unix time stamp
      */
-    public function unix() {
+    public function unix()
+    {
         return $this->unix;
     }
 }

--- a/lib/Element/FeedHtmlField.php
+++ b/lib/Element/FeedHtmlField.php
@@ -1,14 +1,16 @@
 <?php
+
 /**
  * A FeedHtmlField describes and generates
  * a feed, item or image html field (probably a description). Output is
  * generated based on $truncSize, $syndicateHtml properties.
  *
- * @author Pascal Van Hecke <feedcreator.class.php@vanhecke.info>
+ * @author  Pascal Van Hecke <feedcreator.class.php@vanhecke.info>
  * @version 1.6
  * @package de.bitfolge.feedcreator
  */
-class FeedHtmlField {
+class FeedHtmlField
+{
     /**
      * Mandatory attributes of a FeedHtmlField.
      */
@@ -16,16 +18,16 @@ class FeedHtmlField {
 
     /**
      * Optional attributes of a FeedHtmlField.
-     *
      */
     public $truncSize, $syndicateHtml;
 
     /**
      * Creates a new instance of FeedHtmlField.
-     * 
-     * @param  string $parFieldContent if given, sets the rawFieldContent property
+     *
+     * @param string $parFieldContent if given, sets the rawFieldContent property
      */
-    public function __construct($parFieldContent) {
+    public function __construct($parFieldContent)
+    {
         if ($parFieldContent) {
             $this->rawFieldContent = $parFieldContent;
         }
@@ -33,24 +35,26 @@ class FeedHtmlField {
 
     /**
      * Creates the right output, depending on $truncSize, $syndicateHtml properties.
-     * 
-     * @return string    the formatted field
+     *
+     * @return string the formatted field
      */
-    public function output() {
+    public function output()
+    {
         // when field available and syndicated in html we assume
         // - valid html in $rawFieldContent and we enclose in CDATA tags
         // - no truncation (truncating risks producing invalid html)
         if (!$this->rawFieldContent) {
             $result = "";
-        }    elseif ($this->syndicateHtml) {
+        } elseif ($this->syndicateHtml) {
             $result = "<![CDATA[".$this->rawFieldContent."]]>";
         } else {
             if ($this->truncSize and is_int($this->truncSize)) {
-                $result = FeedCreator::iTrunc(htmlspecialchars($this->rawFieldContent),$this->truncSize);
+                $result = FeedCreator::iTrunc(htmlspecialchars($this->rawFieldContent), $this->truncSize);
             } else {
                 $result = htmlspecialchars($this->rawFieldContent);
             }
         }
+
         return $result;
     }
 }

--- a/lib/Element/FeedImage.php
+++ b/lib/Element/FeedImage.php
@@ -1,11 +1,14 @@
 <?php
+
 /**
  * A FeedImage may be added to a FeedCreator feed.
- * @author Kai Blankenhorn <kaib@bitfolge.de>
- * @since 1.3
+ *
+ * @author  Kai Blankenhorn <kaib@bitfolge.de>
+ * @since   1.3
  * @package de.bitfolge.feedcreator
  */
-class FeedImage extends HtmlDescribable {
+class FeedImage extends HtmlDescribable
+{
     /**
      * Mandatory attributes of an image.
      */

--- a/lib/Element/FeedItem.php
+++ b/lib/Element/FeedItem.php
@@ -1,12 +1,14 @@
 <?php
+
 /**
  * A FeedItem is a part of a FeedCreator feed.
  *
- * @author Kai Blankenhorn <kaib@bitfolge.de>
- * @since 1.3
+ * @author  Kai Blankenhorn <kaib@bitfolge.de>
+ * @since   1.3
  * @package de.bitfolge.feedcreator
  */
-class FeedItem extends HtmlDescribable {
+class FeedItem extends HtmlDescribable
+{
     /**
      * Mandatory attributes of an item.
      */
@@ -15,18 +17,15 @@ class FeedItem extends HtmlDescribable {
     /**
      * Optional attributes of an item.
      */
-    public $author, $authorEmail, $authorURL,$image, $category, $categoryScheme, $comments, $guid, $source, $creator, $contributor, $lat, $long, $thumb;
+    public $author, $authorEmail, $authorURL, $image, $category, $categoryScheme, $comments, $guid, $source, $creator, $contributor, $lat, $long, $thumb;
 
     /**
      * Publishing date of an item. May be in one of the following formats:
-     *
      *    RFC 822:
      *    "Mon, 20 Jan 03 18:05:41 +0400"
      *    "20 Jan 03 18:05:41 +0000"
-     *
      *    ISO 8601:
      *    "2003-01-20T18:05:41+04:00"
-     *
      *    Unix:
      *    1043082341
      */
@@ -35,11 +34,8 @@ class FeedItem extends HtmlDescribable {
     /**
      * Add <enclosure> element tag RSS 2.0, supported by ATOM 1.0 too
      * modified by : Mohammad Hafiz bin Ismail (mypapit@gmail.com)
-     *
-     *
      * display :
      * <enclosure length="17691" url="http://something.com/picture.jpg" type="image/jpeg" />
-     *
      */
     public $enclosure;
 

--- a/lib/Element/HtmlDescribable.php
+++ b/lib/Element/HtmlDescribable.php
@@ -1,11 +1,13 @@
 <?php
+
 /**
  * An HtmlDescribable is an item within a feed that can have a description that may
  * include HTML markup.
  *
  * @package de.bitfolge.feedcreator
  */
-class HtmlDescribable {
+class HtmlDescribable
+{
     /**
      * Indicates whether the description field should be rendered in HTML.
      */
@@ -26,10 +28,12 @@ class HtmlDescribable {
      * @param bool $overrideSyndicateHtml
      * @return string the formatted description
      */
-    public function getDescription($overrideSyndicateHtml = false) {
+    public function getDescription($overrideSyndicateHtml = false)
+    {
         $descriptionField = new FeedHtmlField($this->description);
         $descriptionField->syndicateHtml = $overrideSyndicateHtml || $this->descriptionHtmlSyndicated;
         $descriptionField->truncSize = $this->descriptionTruncSize;
+
         return $descriptionField->output();
     }
 }

--- a/lib/UniversalFeedCreator.php
+++ b/lib/UniversalFeedCreator.php
@@ -1,6 +1,6 @@
 <?php
 // your local timezone, set to "" to disable or for GMT
-if(!defined('TIME_ZONE')) {
+if (!defined('TIME_ZONE')) {
     define("TIME_ZONE", date("O", time()));
 }
 
@@ -15,18 +15,20 @@ define("FEEDCREATOR_VERSION", "FeedCreator 1.8");
  * For general usage of a feed class, see the FeedCreator class
  * below or the example above.
  *
- * @since 1.3
- * @author Kai Blankenhorn <kaib@bitfolge.de>
+ * @since   1.3
+ * @author  Kai Blankenhorn <kaib@bitfolge.de>
  * @package de.bitfolge.feedcreator
  */
-class UniversalFeedCreator extends FeedCreator {
-    /** @var  FeedCreator */
+class UniversalFeedCreator extends FeedCreator
+{
+    /** @var FeedCreator */
     protected $_feed;
 
     /**
      * @param string $format
      */
-    protected function _setFormat($format) {
+    protected function _setFormat($format)
+    {
         switch (strtoupper($format)) {
 
             case "BASE":
@@ -114,27 +116,34 @@ class UniversalFeedCreator extends FeedCreator {
     /**
      * Creates a syndication feed based on the items previously added.
      *
-     * @see        FeedCreator::addItem()
-     * @param    string    $format    format the feed should comply to. Valid values are:
-     *            "PIE0.1", "mbox", "RSS0.91", "RSS1.0", "RSS2.0", "OPML", "ATOM0.3", "HTML", "JS"
-     * @return    string    the contents of the feed.
+     * @see FeedCreator::addItem()
+     * @param string $format format the feed should comply to. Valid values are:
+     *                       "PIE0.1", "mbox", "RSS0.91", "RSS1.0", "RSS2.0", "OPML", "ATOM0.3", "HTML", "JS"
+     * @return string the contents of the feed.
      */
-    public function createFeed($format = "RSS0.91") {
+    public function createFeed($format = "RSS0.91")
+    {
         $this->_setFormat($format);
+
         return $this->_feed->createFeed();
     }
 
     /**
      * Saves this feed as a file on the local disk. After the file is saved, an HTTP redirect
      * header may be sent to redirect the use to the newly created file.
-     * @since 1.4
      *
-     * @param    string    $format    format the feed should comply to. Valid values are:
-     *            "PIE0.1" (deprecated), "mbox", "RSS0.91", "RSS1.0", "RSS2.0", "OPML", "ATOM", "ATOM0.3", "HTML", "JS"
-     * @param    string    $filename    optional    the filename where a recent version of the feed is saved. If not specified, the filename is $_SERVER["PHP_SELF"] with the extension changed to .xml (see _generateFilename()).
-     * @param    boolean    $displayContents    optional    send the content of the file or not. If true, the file will be sent in the body of the response.
+     * @since 1.4
+     * @param string $format           format the feed should comply to. Valid values are:
+     *                                 "PIE0.1" (deprecated), "mbox", "RSS0.91", "RSS1.0", "RSS2.0", "OPML", "ATOM",
+     *                                 "ATOM0.3", "HTML", "JS"
+     * @param string $filename         optional    the filename where a recent version of the feed is saved. If not
+     *                                 specified, the filename is $_SERVER["PHP_SELF"] with the extension changed to
+     *                                 .xml (see _generateFilename()).
+     * @param boolean $displayContents optional    send the content of the file or not. If true, the file will be sent
+     *                                 in the body of the response.
      */
-    public function saveFeed($format="RSS0.91", $filename="", $displayContents=true) {
+    public function saveFeed($format = "RSS0.91", $filename = "", $displayContents = true)
+    {
         $this->_setFormat($format);
         $this->_feed->saveFeed($filename, $displayContents);
     }
@@ -146,12 +155,16 @@ class UniversalFeedCreator extends FeedCreator {
      * before anything else, especially before you do the time consuming task to build the feed
      * (web fetching, for example).
      *
-     * @param   string   $format   format the feed should comply to. Valid values are:
-     *       "PIE0.1" (deprecated), "mbox", "RSS0.91", "RSS1.0", "RSS2.0", "OPML", "ATOM0.3".
-     * @param string $filename    optional the filename where a recent version of the feed is saved. If not specified, the filename is $_SERVER["PHP_SELF"] with the extension changed to .xml (see _generateFilename()).
-     * @param int $timeout      optional the timeout in seconds before a cached version is refreshed (defaults to 3600 = 1 hour)
+     * @param string $format   format the feed should comply to. Valid values are:
+     *                         "PIE0.1" (deprecated), "mbox", "RSS0.91", "RSS1.0", "RSS2.0", "OPML", "ATOM0.3".
+     * @param string $filename optional the filename where a recent version of the feed is saved. If not specified, the
+     *                         filename is $_SERVER["PHP_SELF"] with the extension changed to .xml (see
+     *                         _generateFilename()).
+     * @param int $timeout     optional the timeout in seconds before a cached version is refreshed (defaults to 3600 =
+     *                         1 hour)
      */
-    public function useCached($format="RSS0.91", $filename="", $timeout=3600) {
+    public function useCached($format = "RSS0.91", $filename = "", $timeout = 3600)
+    {
         $this->_setFormat($format);
         $this->_feed->useCached($filename, $timeout);
     }

--- a/test/Creator/AtomCreator10Test.php
+++ b/test/Creator/AtomCreator10Test.php
@@ -1,4 +1,5 @@
 <?php
+
 class AtomCreator10Test extends PHPUnit_Framework_TestCase
 {
     public function test_create_empty_feed()

--- a/test/Creator/RSSCreator10Test.php
+++ b/test/Creator/RSSCreator10Test.php
@@ -1,4 +1,5 @@
 <?php
+
 class RSSCreator10Test extends PHPUnit_Framework_TestCase
 {
     public function test_create_empty_feed()

--- a/test/UniversalFeedCreatorTest.php
+++ b/test/UniversalFeedCreatorTest.php
@@ -1,4 +1,5 @@
 <?php
+
 class UniversalFeedCreatorTest extends PHPUnit_Framework_TestCase
 {
     /**
@@ -10,7 +11,7 @@ class UniversalFeedCreatorTest extends PHPUnit_Framework_TestCase
         $creator->addItem(new FeedItem());
         $feed = $creator->createFeed($format);
 
-        $expected = simplexml_load_file(__DIR__ . DIRECTORY_SEPARATOR . '__files'  . DIRECTORY_SEPARATOR . $expected);
+        $expected = simplexml_load_file(__DIR__.DIRECTORY_SEPARATOR.'__files'.DIRECTORY_SEPARATOR.$expected);
         $actual = simplexml_load_string($feed);
         $this->assertEquals($expected->getName(), $actual->getName());
         $this->assertEquals($expected->attributes(), $actual->attributes());
@@ -28,7 +29,7 @@ class UniversalFeedCreatorTest extends PHPUnit_Framework_TestCase
         $creator->addItem(new FeedItem());
         $feed = $creator->createFeed('RSS2.0');
 
-        $expected = simplexml_load_file(__DIR__ . DIRECTORY_SEPARATOR . '__files'  . DIRECTORY_SEPARATOR . 'rss091.xml');
+        $expected = simplexml_load_file(__DIR__.DIRECTORY_SEPARATOR.'__files'.DIRECTORY_SEPARATOR.'rss091.xml');
         $actual = simplexml_load_string($feed);
         $this->assertEquals($expected->channel->description, $actual->channel->description);
     }

--- a/test/__files/rss091.xml
+++ b/test/__files/rss091.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- generator="FeedCreator 1.8" -->
 <rss version="0.91">
-    <channel xmlns:g="http://base.google.com/ns/1.0">
+    <channel>
         <title>Feed Title</title>
         <description>Feed Description</description>
         <link>http://link.to/blog</link>

--- a/test/__files/rss091empty.xml
+++ b/test/__files/rss091empty.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- generator="FeedCreator 1.8" -->
 <rss version="0.91">
-    <channel xmlns:g="http://base.google.com/ns/1.0">
+    <channel>
         <title></title>
         <description></description>
         <link></link>

--- a/test/__files/rss10empty.xml
+++ b/test/__files/rss10empty.xml
@@ -2,15 +2,14 @@
 <!-- generator="FeedCreator 1.8" -->
 <?xml-stylesheet href="http://www.w3.org/2000/08/w3c-synd/style.css" type="text/css"?>
 <rdf:RDF
-    xmlns="http://purl.org/rss/1.0/"
-    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-    xmlns:slash="http://purl.org/rss/1.0/modules/slash/"
-    xmlns:dc="http://purl.org/dc/elements/1.1/">
+        xmlns="http://purl.org/rss/1.0/"
+        xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+        xmlns:dc="http://purl.org/dc/elements/1.1/">
     <channel rdf:about="">
         <title></title>
         <description></description>
         <link></link>
-       <dc:date>2013-03-12T22:03:11+00:00</dc:date>
+        <dc:date>2013-03-12T22:03:11+00:00</dc:date>
         <items>
             <rdf:Seq>
                 <rdf:li rdf:resource=""/>

--- a/test/__files/rss20empty.xml
+++ b/test/__files/rss20empty.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- generator="FeedCreator 1.8" -->
 <rss version="2.0">
-    <channel xmlns:g="http://base.google.com/ns/1.0">
+    <channel>
         <title></title>
         <description></description>
         <link></link>

--- a/test/rootfile.php
+++ b/test/rootfile.php
@@ -1,12 +1,11 @@
 <?php
 /**
  * PHP Unit bootstrapping
- *
  * the used phpunit version depends on the available PHP version, newer versions are namespaced
  * whiler older ones are not.
  */
 
-require dirname(__DIR__) . '/vendor/autoload.php';
+require dirname(__DIR__).'/vendor/autoload.php';
 
 if (
     !class_exists('\PHPUnit_Framework_TestCase')


### PR DESCRIPTION
This reformats the code according to PSR1 and PSR2. An .editorconfig setup is added to enforce a minimal subset of that standard in supported editors.

No functional change was made here.

Changes for introducing PSR-0/4 compatible namespacing should be next, but would require a major version bump.