### PR TITLE
For Yandex Turbo Pages

### DIFF
--- a/lib/Creator/RSSCreator091.php
+++ b/lib/Creator/RSSCreator091.php
@@ -128,7 +128,7 @@ class RSSCreator091 extends FeedCreator
         $feed .= $this->_createAdditionalElements($this->additionalElements, "    ");
 
         for ($i = 0; $i < count($this->items); $i++) {
-            $feed .= "        <item>\n";
+            $feed .= "        <item turbo=\"true\">\n";
             $feed .= "            <title>".FeedCreator::iTrunc(
                     htmlspecialchars(strip_tags($this->items[$i]->title)),
                     100


### PR DESCRIPTION
Addition of <item turbo="true"> for [Yandex Turbo Pages](https://yandex.ru/dev/turbo/doc/rss/simple-rss-docpage/), a mobile browsing accelerator through RSS feed